### PR TITLE
Unparser for viewing desugared (maybe optimized) programs

### DIFF
--- a/bin/dice.ml
+++ b/bin/dice.ml
@@ -45,7 +45,7 @@ let get_lexing_position lexbuf =
   (line_number, column)
 
 let parse_and_print ~print_parsed ~print_internal ~print_size ~skip_table
-    ~inline_functions ~sample_amount ~show_recursive_calls ~optimize lexbuf : result List.t = try
+    ~inline_functions ~sample_amount ~show_recursive_calls ~optimize ~print_unparsed lexbuf : result List.t = try
   let parsed = Compiler.parse_with_error lexbuf in
   let res = if print_parsed then [StringRes("Parsed program", (ExternalGrammar.string_of_prog parsed))] else [] in
   let (t, internal) =
@@ -57,6 +57,7 @@ let parse_and_print ~print_parsed ~print_internal ~print_size ~skip_table
       (from_external_prog_optimize parsed)
     else from_external_prog parsed in
   let res = if print_internal then res @ [StringRes("Parsed program", CoreGrammar.string_of_prog internal)] else res in
+  let res = if print_unparsed then res @ [StringRes("Parsed program", CoreGrammar.string_of_prog_unparsed internal)] else res in
   match sample_amount with
   | None ->
     let compiled = Compiler.compile_program internal in
@@ -141,6 +142,7 @@ let command =
      and optimize = flag "-optimize" no_arg ~doc:" optimize dice program before compilation"
      and inline_functions = flag "-inline-functions" no_arg ~doc:" inline all function calls"
      and print_internal = flag "-show-internal" no_arg ~doc:" print desugared dice program"
+     and print_unparsed = flag "-show-unparsed" no_arg ~doc:" print unparsed desugared dice program"
      and skip_table = flag "-skip-table" no_arg ~doc:" skip printing the joint probability distribution"
      and show_recursive_calls = flag "-num-recursive-calls" no_arg ~doc:" show the number of recursive calls invoked during compilation"
      (* and print_marginals = flag "-show-marginals" no_arg ~doc:" print the marginal probabilities of a tuple in depth-first order" *)
@@ -150,7 +152,7 @@ let command =
        let lexbuf = Lexing.from_channel inx in
        lexbuf.lex_curr_p <- { lexbuf.lex_curr_p with pos_fname = fname };
        let r = (parse_and_print ~print_parsed ~print_internal ~sample_amount
-                  ~print_size ~inline_functions ~skip_table ~optimize ~show_recursive_calls lexbuf) in
+                  ~print_size ~inline_functions ~skip_table ~optimize ~show_recursive_calls ~print_unparsed lexbuf) in
        if json then Format.printf "%s" (Yojson.to_string (`List(List.map r ~f:json_res)))
        else List.iter r ~f:print_res
     )

--- a/lib/CoreGrammar.ml
+++ b/lib/CoreGrammar.ml
@@ -104,11 +104,16 @@ let string_of_prog_unparsed p =
     | Let(x, e1, e2) ->
       let s1 = pr_expr e1 in
       let s2 = pr_expr e2 in
-      Format.asprintf "@[<hov 2>%s@ %s@ %s@;%s@;%s@.@]%s" "let" x "=" s1 "in" s2
-    | Flip(f) -> Format.asprintf "flip %s" (flo f)
-    | True -> Format.asprintf "true"
-    | False -> Format.asprintf "false"
-    | _ -> Format.sprintf ""
+      Format.dprintf "@[<hov 2>%s@ %s@ %s@;%t@;%s@.@]%t" "let" x "=" s1 "in" s2
+    | Ite(g, thn, els) ->
+      let s0 = pr_expr g in
+      let s1 = pr_expr thn in
+      let s2 = pr_expr els in
+      Format.dprintf "@[<hov>@[<hov 2>%s@ %t@ %s@\n%t@]@\n@[<hov 2>%s@\n%t@]@]" "if" s0 "then" s1 "else" s2
+    | Flip(f) -> Format.dprintf "flip %s" (flo f)
+    | True -> Format.dprintf "true"
+    | False -> Format.dprintf "false"
+    | _ -> Format.dprintf ""
   in 
 
-  Format.asprintf "@[<hov 2>%s@]\n" (pr_expr e)
+  Format.asprintf "@[<hov 2>%t@]\n" (pr_expr e)

--- a/lib/CoreGrammar.ml
+++ b/lib/CoreGrammar.ml
@@ -165,6 +165,6 @@ let string_of_prog_unparsed p =
         | (var, typ)::tail -> 
           List.fold tail ~init:(Format.dprintf "%s: %s" var (string_of_type typ)) ~f:(fun prev (var, typ) -> Format.dprintf "%t,@ %t" prev (Format.dprintf "%s: %s" var (string_of_type typ)))
     in
-    Format.dprintf "@[%t\n@[fun@ %s(%t)@]@\n@[{@;<1 2>%t@;}@]@]\n" prev func.name string_of_args (pr_func func.body)
+    Format.dprintf "@[%t\n@[fun@ %s(%t)@]@\n@<100>{@;<1 2>%t@;}@]\n" prev func.name string_of_args (pr_func func.body)
   ) in
   Format.asprintf "%s%s" (Format.asprintf "%t\n" string_of_functions) (Format.asprintf "%t\n" (pr_func body))

--- a/lib/CoreGrammar.ml
+++ b/lib/CoreGrammar.ml
@@ -107,6 +107,7 @@ let string_of_prog_unparsed p =
     | Observe(_) -> "observe"
     | Fst(_) -> "fst"
     | Snd(_) -> "snd"
+    | Sample(_) -> "sample"
     | _ -> ""
   in
 
@@ -132,7 +133,7 @@ let string_of_prog_unparsed p =
     | Not(e1) -> 
       let s1 = pr_expr e1 in
       Format.dprintf "!%t" s1
-    | Observe(e1) | Fst(e1) | Snd(e1) ->
+    | Observe(e1) | Fst(e1) | Snd(e1) | Sample(e1) ->
       let s1 = pr_expr e1 in
       Format.dprintf "@[<hov 2>%s@ %t@]" (string_of_op e) s1
     | Flip(f) -> Format.dprintf "flip %s" (flo f)
@@ -148,7 +149,6 @@ let string_of_prog_unparsed p =
       Format.dprintf "@[<hov 2>%s(%t)@]" id args_s
     | True -> Format.dprintf "true"
     | False -> Format.dprintf "false"
-    | _ -> Format.dprintf ""
   in 
 
   Format.asprintf "@[<hov 2>%t@]\n" (pr_expr e)

--- a/lib/CoreGrammar.ml
+++ b/lib/CoreGrammar.ml
@@ -137,6 +137,15 @@ let string_of_prog_unparsed p =
       Format.dprintf "@[<hov 2>%s@ %t@]" (string_of_op e) s1
     | Flip(f) -> Format.dprintf "flip %s" (flo f)
     | Ident(s) -> Format.dprintf "%s" s
+    | FuncCall(id, args) ->
+      let args_s = 
+        match args with
+        | [] -> Format.dprintf ""
+        | head::[] -> Format.dprintf "%t" (pr_expr head)
+        | head::tail -> 
+          List.fold tail ~init:(Format.dprintf "%t" (pr_expr head)) ~f:(fun prev arg -> Format.dprintf "%t,@ %t" prev (pr_expr arg))
+      in
+      Format.dprintf "@[<hov 2>%s(%t)@]" id args_s
     | True -> Format.dprintf "true"
     | False -> Format.dprintf "false"
     | _ -> Format.dprintf ""

--- a/lib/CoreGrammar.ml
+++ b/lib/CoreGrammar.ml
@@ -104,13 +104,19 @@ let string_of_prog_unparsed p =
     | Let(x, e1, e2) ->
       let s1 = pr_expr e1 in
       let s2 = pr_expr e2 in
-      Format.dprintf "@[<hov 2>%s@ %s@ %s@;%t@;%s@.@]%t" "let" x "=" s1 "in" s2
+      Format.dprintf "@[<hov 2>let@ %s@ =@;%t@;in@.@]%t" x s1 s2
     | Ite(g, thn, els) ->
       let s0 = pr_expr g in
       let s1 = pr_expr thn in
       let s2 = pr_expr els in
-      Format.dprintf "@[<hov>@[<hov 2>%s@ %t@ %s@\n%t@]@\n@[<hov 2>%s@\n%t@]@]" "if" s0 "then" s1 "else" s2
+      Format.dprintf "@[<hv>@[if@;<1 2>%t@;then@]@;<1 2>@[%t@]@;else@;<1 2>@[%t@]@]" s0 s1 s2
+    | And(e1, e2) -> 
+      let s1 = pr_expr e1 in
+      let s2 = pr_expr e2 in
+      Format.dprintf "@[<hov 2>%t@ %s@;%t@]" s1 "&&" s2
+    (* | Xor(_, _) | Eq(_, _) | Or(_, _) | Not(_) | True | False | Flip(_) | Observe(_) -> *)
     | Flip(f) -> Format.dprintf "flip %s" (flo f)
+    | Ident(s) -> Format.dprintf "%s" s
     | True -> Format.dprintf "true"
     | False -> Format.dprintf "false"
     | _ -> Format.dprintf ""

--- a/lib/CoreGrammar.ml
+++ b/lib/CoreGrammar.ml
@@ -97,24 +97,44 @@ let string_of_prog_unparsed p =
   let e = p.body in
   let functions = p.functions in 
 
-  let flo f = Format.asprintf "%f" f in
+  let flo f = Format.asprintf "%f" f 
+  and string_of_op e = 
+    match e with 
+    | And(_, _) -> "&&"
+    | Xor(_, _) -> "^"
+    | Eq(_, _) -> "=="
+    | Or(_, _) -> "||"
+    | Observe(_) -> "observe"
+    | Fst(_) -> "fst"
+    | Snd(_) -> "snd"
+    | _ -> ""
+  in
 
   let rec pr_expr e = 
     match e with
     | Let(x, e1, e2) ->
       let s1 = pr_expr e1 in
       let s2 = pr_expr e2 in
-      Format.dprintf "@[<hov 2>let@ %s@ =@;%t@;in@.@]%t" x s1 s2
+      Format.dprintf "@[<hv>@[let@ %s@ =@;<1 2>%t@;in@]@\n%t@]" x s1 s2
     | Ite(g, thn, els) ->
       let s0 = pr_expr g in
       let s1 = pr_expr thn in
       let s2 = pr_expr els in
       Format.dprintf "@[<hv>@[if@;<1 2>%t@;then@]@;<1 2>@[%t@]@;else@;<1 2>@[%t@]@]" s0 s1 s2
-    | And(e1, e2) -> 
+    | And(e1, e2) | Xor(e1, e2) | Eq(e1, e2) | Or(e1, e2) -> 
       let s1 = pr_expr e1 in
       let s2 = pr_expr e2 in
-      Format.dprintf "@[<hov 2>%t@ %s@;%t@]" s1 "&&" s2
-    (* | Xor(_, _) | Eq(_, _) | Or(_, _) | Not(_) | True | False | Flip(_) | Observe(_) -> *)
+      Format.dprintf "@[<hov 2>%t@ %s@;%t@]" s1 (string_of_op e) s2
+    | Tup(e1, e2) ->
+      let s1 = pr_expr e1 in
+      let s2 = pr_expr e2 in
+      Format.dprintf "@[<hov 2>(%t,@ %t)@]" s1 s2
+    | Not(e1) -> 
+      let s1 = pr_expr e1 in
+      Format.dprintf "!%t" s1
+    | Observe(e1) | Fst(e1) | Snd(e1) ->
+      let s1 = pr_expr e1 in
+      Format.dprintf "@[<hov 2>%s@ %t@]" (string_of_op e) s1
     | Flip(f) -> Format.dprintf "flip %s" (flo f)
     | Ident(s) -> Format.dprintf "%s" s
     | True -> Format.dprintf "true"

--- a/lib/CoreGrammar.ml
+++ b/lib/CoreGrammar.ml
@@ -93,3 +93,22 @@ type program = {
 let string_of_prog e =
   Sexp.to_string_hum (sexp_of_program e)
 
+let string_of_prog_unparsed p =
+  let e = p.body in
+  let functions = p.functions in 
+
+  let flo f = Format.asprintf "%f" f in
+
+  let rec pr_expr e = 
+    match e with
+    | Let(x, e1, e2) ->
+      let s1 = pr_expr e1 in
+      let s2 = pr_expr e2 in
+      Format.asprintf "@[<hov 2>%s@ %s@ %s@;%s@;%s@.@]%s" "let" x "=" s1 "in" s2
+    | Flip(f) -> Format.asprintf "flip %s" (flo f)
+    | True -> Format.asprintf "true"
+    | False -> Format.asprintf "false"
+    | _ -> Format.sprintf ""
+  in 
+
+  Format.asprintf "@[<hov 2>%s@]\n" (pr_expr e)

--- a/lib/CoreGrammar.mli
+++ b/lib/CoreGrammar.mli
@@ -60,3 +60,4 @@ val type_of_fun : tenv -> func -> typ
 
 val string_of_expr : expr -> String.t
 val string_of_prog : program -> String.t
+val string_of_prog_unparsed : program -> String.t


### PR DESCRIPTION
Use the flag `-show-unparsed` to view the unparsed Dice program after the desugaring and the optimization passes.