### PR TITLE
Flip-lifting 2.0

### DIFF
--- a/lib/Optimization.ml
+++ b/lib/Optimization.ml
@@ -255,12 +255,12 @@ let down_pass (e: CG.expr) (t: tree) : CG.expr =
       | (used, new_flip, f, var, s)::tail ->
         let used', new_flip', f', var', s' = flip_to_var_entry in
         if var = var' && f = f' then
-          ((used || used'), (new_flip || new_flip'), f', var', (merge_s s' s [])), (List.rev_append flip_to_var_els_head tail)
+          ((used || used'), (new_flip && new_flip'), f', var', (merge_s s' s [])), (List.rev_append flip_to_var_els_head tail)
         else
           concatenate_squeezed_exprs_e flip_to_var_entry ((used, new_flip, f, var, s)::flip_to_var_els_head) tail 
     in
     match flip_to_var_thn with
-    | [] -> (List.rev_append flip_to_var_head flip_to_var_els)
+    | [] -> (List.rev_append (List.rev_append flip_to_var_els []) (List.rev_append flip_to_var_head []))
     | head::tail ->
       let head', flip_to_var_els' = concatenate_squeezed_exprs_e head [] flip_to_var_els in
       concatenate_squeezed_exprs (head'::flip_to_var_head) tail flip_to_var_els' 
@@ -297,7 +297,7 @@ let down_pass (e: CG.expr) (t: tree) : CG.expr =
         let expr = make_squeezed s (Let(var, Flip(f), inner)) in
         make_expression tail var_to_expr expr 
       else
-        make_expression tail var_to_expr inner
+        inner
   in
 
   let rec clean_bookkeeping (flip_to_var_before: tracker) (flip_to_var_head: tracker) (flip_to_var: tracker) (var_to_expr: env) : tracker * env = 

--- a/lib/Optimization.ml
+++ b/lib/Optimization.ml
@@ -358,9 +358,10 @@ let down_pass (e: CG.expr) (t: tree) : CG.expr =
             (match g with 
             | Ident(x) -> 
               if StringMap.mem x var_to_expr' then
-                let ident_lifted, flip_to_var_lifted_ident = lift_ident flip_to_var' x flips in 
+                let Ident(new_x) = StringMap.find x var_to_expr' in
+                let ident_lifted, flip_to_var_lifted_ident = lift_ident flip_to_var' new_x flips in 
                 if ident_lifted then
-                  g, flip_to_var_lifted_ident, var_to_expr'
+                  Ident(new_x), flip_to_var_lifted_ident, var_to_expr'
                 else
                   failwith "can't find lifted flips"
               else
@@ -393,10 +394,11 @@ let down_pass (e: CG.expr) (t: tree) : CG.expr =
         if (List.length e1_flips) != 0 then
           let e1', flip_to_var', var_to_expr' = down_pass_e e1 flip_to_var var_to_expr e1_tree in
           (* Save x to var_to_expr and recurse*)
-          let var_to_expr'' = StringMap.add x e1' var_to_expr' in
+          let new_x = fresh() in
+          let var_to_expr'' = StringMap.add new_x e1' (StringMap.add x (Ident(new_x)) var_to_expr') in
           let e2', flip_to_var_new, var_to_expr_new = down_pass_e e2 flip_to_var' var_to_expr'' e2_tree in
           let new_expr = 
-            if is_var_lifted flip_to_var_new x then
+            if is_var_lifted flip_to_var_new new_x then
               e2'
             else
               Let(x, e1', e2')

--- a/lib/Optimization.ml
+++ b/lib/Optimization.ml
@@ -284,7 +284,7 @@ let down_pass (e: CG.expr) (t: tree) : CG.expr =
       | var::tail ->
         let expr = 
           match StringMap.find_opt var var_to_expr with
-          | None -> failwith "can't find %s" var
+          | None -> failwith "can't find var to make"
           | Some(e) -> 
             let var_still_exists = StringMap.exists (fun _ e1 -> rec_check_var_exists e1 var) var_to_expr in
             if var_still_exists then
@@ -451,7 +451,7 @@ let down_pass (e: CG.expr) (t: tree) : CG.expr =
               g, flip_to_var', (StringMap.add x new_expr var_to_expr'')))
     | Flip(_) -> 
       let new_v = fresh() in
-      let flip_found, ident_lifted, flip_to_var_lifted_ident = lift_ident flip_to_var new_v flips [] in 
+      let flip_found, _, flip_to_var_lifted_ident = lift_ident flip_to_var new_v flips [] in 
       if flip_found then
         (* let var_to_expr' = if ident_lifted then  else var_to_expr in *)
         Ident(new_v), flip_to_var_lifted_ident, (StringMap.add new_v g var_to_expr)


### PR DESCRIPTION
Revamped, more understandable, and more generalizable flip-lifting.

Tests:
`dune test` all passes. Manual verification with some results of benchmarks (alarm, water, insurance, hepar2, pigs, munin) show the results are correct. 

Major differences:
- Does not assume only flips are lifted in the process. Idents can also be lifted. This is especially necessary for maintaining lexicological ordering when lifting flips, since many of the guards uses Idents. 
- Lifts flips within logical expressions, within guards, and within let expressions that are in mutually exclusive execution paths.
- Properly maintains lexicological ordering by inspecting dependent let expressions, so the BDD size should only ever be less than or equal to the original. 
- Performs branch elimination before and after the flip-lifting.

Next step:
- Expressions that are "partially lifted" do not get flip-lifting because there is no way to tell if two variables share the same execution path or not. This is an example:
```OCaml
let x = if flip 0.2 then flip 0.4 else flip 0.2 in
let y = if flip 0.4 then flip 0.2 else flip 0.4 in
let z = if flip 0.5 then x else y in
z
```