### PR TITLE
Add lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,10 +168,10 @@ Breaking this program down:
 - `head xs` returns the first element of `xs` and `tail xs` returns a list of everything after the first element.
 - `x :: xs` returns a list with `x` added to the front of `xs`.
 
-Running this program, with `-max-list-length 3`:
+Running this program:
 
 ```
-> dice resources/list-ex.dice
+> dice -max-list-length 3 resources/list-ex.dice
 Value   Probability
 []      0.
 [true]  0.2

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ false	0.651163
 This output shows that `a` has a 34.8837% chance of landing on heads.
 
 ## Datatypes
-In addition to Booleans, `dice` supports integers and tuples.
+In addition to Booleans, `dice` supports integers, tuples, and lists.
 
 ### Tuples
 
@@ -151,6 +151,43 @@ Value	Probability
 0	0.500000
 1	0.400000
 2	0.100000
+```
+
+### Lists
+
+`dice` supports distributions over lists, possibly of different lengths.
+
+```
+let xs = [flip 0.2, flip 0.4] in
+if flip 0.5 then (head xs) :: xs else tail xs
+```
+
+Breaking this program down:
+
+- `[flip 0.2, flip 0.4]` creates a list of Booleans with two elements.
+- `head xs` returns the first element of `xs` and `tail xs` returns a list of everything after the first element.
+- `x :: xs` returns a list with `x` added to the front of `xs`.
+
+Running this program, with `-max-list-length 3`:
+
+```
+> dice resources/list-ex.dice
+Value   Probability
+[]      0.
+[true]  0.2
+[false] 0.3
+[true, true]    0.
+[true, false]   0.
+[false, true]   0.
+[false, false]  0.
+[true, true, true]      0.04
+[true, true, false]     0.06
+[true, false, true]     0.
+[true, false, false]    0.
+[false, true, true]     0.
+[false, true, false]    0.
+[false, false, true]    0.16
+[false, false, false]   0.24
 ```
 
 ## Functions
@@ -265,7 +302,7 @@ complete syntax for `dice` in is:
 
 ```
 ident := ['a'-'z' 'A'-'Z' '_'] ['a'-'z' 'A'-'Z' '0'-'9' '_']*
-binop := +, -, *, /, <, <=, >, >=, ==, !=, &&, ||, <=>, ^
+binop := +, -, *, /, <, <=, >, >=, ==, !=, &&, ||, <=>, ^, ::
 
 expr := 
    (expr)
@@ -282,8 +319,13 @@ expr :=
    | observe expr
    | if expr then expr else expr
    | let ident = expr in expr
+   | [ expr (, expr)* ]
+   | [] : type
+   | head expr
+   | tail expr
+   | length expr
 
-type := bool | (type, type) | int(size)
+type := bool | (type, type) | int(size) | list(type)
 arg := ident: type
 function := fun name(arg1, ...) { expr }
 

--- a/bin/dice.ml
+++ b/bin/dice.ml
@@ -67,7 +67,7 @@ let parse_and_print ~print_parsed ~print_internal ~print_size ~skip_table
   let res = if print_parsed then [StringRes("Parsed program", (ExternalGrammar.string_of_prog parsed))] else [] in
   let parsed_norec = Passes.expand_recursion ?recursion_limit parsed in
   let cfg =
-    { max_list_length = Option.value max_list_length
+    { max_list_length = Option.value (Option.first_some max_list_length recursion_limit)
         ~default:Passes.default_config.max_list_length } in
   let optimize = flip_lifting || branch_elimination || determinism in
   let (t, internal) =

--- a/bin/dice.ml
+++ b/bin/dice.ml
@@ -44,23 +44,40 @@ let get_lexing_position lexbuf =
   let column = p.Lexing.pos_cnum - p.Lexing.pos_bol + 1 in
   (line_number, column)
 
+let rec print_pretty e =
+  match e with
+  | `Int(v) -> string_of_int v
+  | `True -> "true"
+  | `False -> "false"
+  | `Tup(l, r) -> Format.sprintf "(%s, %s)" (print_pretty l) (print_pretty r)
+  | `List(values) ->
+    let rec format_elems = function
+    | [] -> ""
+    | [v] -> print_pretty v
+    | v::vs -> print_pretty v ^ ", " ^ format_elems vs in
+    "[" ^ format_elems values ^ "]"
+
 let parse_and_print ~print_parsed ~print_internal ~print_size ~skip_table
     ~inline_functions ~sample_amount ~show_recursive_calls
     ~flip_lifting ~branch_elimination ~determinism ~print_state_bdd
-    ~show_function_size ~print_unparsed ~print_function_bdd ~recursion_limit
+    ~show_function_size ~print_unparsed ~print_function_bdd
+    ~recursion_limit ~max_list_length
     lexbuf : result List.t = try
   let parsed = Compiler.parse_with_error lexbuf in
   let res = if print_parsed then [StringRes("Parsed program", (ExternalGrammar.string_of_prog parsed))] else [] in
   let parsed_norec = Passes.expand_recursion ?recursion_limit parsed in
+  let cfg =
+    { max_list_length = Option.value max_list_length
+        ~default:Passes.default_config.max_list_length } in
   let optimize = flip_lifting || branch_elimination || determinism in
   let (t, internal) =
     if inline_functions && optimize then
-      (from_external_prog_optimize (Passes.inline_functions parsed_norec) flip_lifting branch_elimination determinism)
+      (from_external_prog_optimize ~cfg (Passes.inline_functions parsed_norec) flip_lifting branch_elimination determinism)
     else if inline_functions && not optimize then
-      (from_external_prog (Passes.inline_functions parsed_norec))
+      (from_external_prog ~cfg (Passes.inline_functions parsed_norec))
     else if not inline_functions && optimize then
-      (from_external_prog_optimize parsed_norec flip_lifting branch_elimination determinism)
-    else from_external_prog parsed_norec in
+      (from_external_prog_optimize ~cfg parsed_norec flip_lifting branch_elimination determinism)
+    else from_external_prog ~cfg parsed_norec in
   let res = if print_internal then res @ [StringRes("Parsed program", CoreGrammar.string_of_prog internal)] else res in
   let res = if print_unparsed then res @ [StringRes("Parsed program", CoreGrammar.string_of_prog_unparsed internal)] else res in
   match sample_amount with
@@ -69,21 +86,13 @@ let parse_and_print ~print_parsed ~print_internal ~print_size ~skip_table
     let zbdd = compiled.body.z in
     let res = if skip_table then res else res @
        (let z = Wmc.wmc zbdd compiled.ctx.weights in
-       let table = VarState.get_table compiled.body.state t in
+       let table = VarState.get_table cfg compiled.body.state t in
        let probs = List.map table ~f:(fun (label, bdd) ->
            if Util.within_epsilon z 0.0 then (label, 0.0) else
              let prob = (Wmc.wmc (Bdd.dand bdd zbdd) compiled.ctx.weights) /. z in
              (label, prob)) in
-       let l = [["Value"; "Probability"]] @ List.map probs ~f:(fun (typ, prob) ->
-           let rec print_pretty e =
-             match e with
-             | `Int(v) -> string_of_int v
-             | `True -> "true"
-             | `False -> "false"
-             | `Tup(l, r) -> Format.sprintf "(%s, %s)" (print_pretty l) (print_pretty r)
-             | _ -> failwith "ouch" in
-           [print_pretty typ; string_of_float prob]
-         ) in
+       let l = [["Value"; "Probability"]] @
+         List.map probs ~f:(fun (typ, prob) -> [print_pretty typ; string_of_float prob]) in
        [TableRes("Joint Distribution", l)]
       ) in
     let res = if show_recursive_calls then res @ [StringRes("Number of recursive calls",
@@ -121,7 +130,7 @@ let parse_and_print ~print_parsed ~print_internal ~print_size ~skip_table
       else
         let compiled = Compiler.compile_program internal in
         sz := !sz + VarState.state_size [compiled.body.state; Leaf(compiled.body.z)];
-        let table = VarState.get_table compiled.body.state t in
+        let table = VarState.get_table cfg compiled.body.state t in
         let zbdd = compiled.body.z in
         let z = Wmc.wmc zbdd compiled.ctx.weights in
         let probs = List.map table ~f:(fun (label, bdd) ->
@@ -135,16 +144,9 @@ let parse_and_print ~print_parsed ~print_internal ~print_size ~skip_table
            draw_sample (Some(summed), z +. oldz) (n-1)) in
     let (res_state, z) = draw_sample (None, 0.0) n in
     let res = if skip_table then [] else
-        let l = [["Value"; "Probability"]] @ List.map (Option.value_exn res_state) ~f:(fun (typ, prob) ->
-            let rec print_pretty e =
-              match e with
-              | `Int(v) -> string_of_int v
-              | `True -> "true"
-              | `False -> "false"
-              | `Tup(l, r) -> Format.sprintf "(%s, %s)" (print_pretty l) (print_pretty r)
-              | _ -> failwith "ouch" in
-            [print_pretty typ; string_of_float (prob /. z)]
-          ) in
+        let l = [["Value"; "Probability"]] @
+          List.map (Option.value_exn res_state) ~f:(fun (typ, prob) ->
+            [print_pretty typ; string_of_float (prob /. z)]) in
         [TableRes("Joint Probability", l)] in
     let res = if print_size then
         res @ [StringRes("Compiled BDD size", string_of_float(float_of_int !sz /. float_of_int n))] else res in
@@ -176,6 +178,7 @@ let command =
      and skip_table = flag "-skip-table" no_arg ~doc:" skip printing the joint probability distribution"
      and show_recursive_calls = flag "-num-recursive-calls" no_arg ~doc:" show the number of recursive calls invoked during compilation"
      and recursion_limit = flag "-recursion-limit" (optional int) ~doc:" maximum recursion depth"
+     and max_list_length = flag "-max-list-length" (optional int) ~doc:" maximum list length"
      (* and print_marginals = flag "-show-marginals" no_arg ~doc:" print the marginal probabilities of a tuple in depth-first order" *)
      and json = flag "-json" no_arg ~doc:" print output as JSON"
      in fun () ->
@@ -185,7 +188,8 @@ let command =
        let r = (parse_and_print ~print_parsed ~print_internal ~sample_amount
                   ~print_size ~inline_functions ~skip_table ~flip_lifting
                   ~branch_elimination ~determinism ~show_recursive_calls ~print_state_bdd
-                  ~show_function_size ~print_unparsed ~print_function_bdd ~recursion_limit
+                  ~show_function_size ~print_unparsed ~print_function_bdd
+                  ~recursion_limit ~max_list_length
                   lexbuf) in
        if json then Format.printf "%s" (Yojson.to_string (`List(List.map r ~f:json_res)))
        else List.iter r ~f:print_res

--- a/docs/lists.md
+++ b/docs/lists.md
@@ -1,0 +1,32 @@
+# Lists
+
+## Syntax
+
+- Nonempty list literal: `[ expr (, expr)* ]`
+- Empty list literal: `[] : type`
+- Cons: `expr :: expr`
+- Head: `head expr`
+- Tail: `tail expr`
+- Length: `length expr`
+
+## Static semantics
+
+- If `x1 : T`, `x2 : T`, ..., `xn : T` then `[x1, x2, ..., xn] : list(T)`
+- `([] : list(T)) : list(T)`
+- If `x : T` and `xs : list(T)` then `(x :: xs) : list(T)`
+- If `xs : list(T)` then `head xs : T` and `tail xs : list(T)`
+- If the maximum list length is `N` and `n = floor(log_2(N)) + 1` (the number of bits required to express `N`) then `length xs : int(n)`
+
+## Dynamic semantics
+
+- `[x1, x2, ..., xn]` returns a list of `n` elements containing `x1`, `x2`, ..., `xn`.
+- `[] : T` returns an empty list.
+- `x :: xs` returns `x` added to the front of `xs`. If this exceeds the maximum list length then the last element in `xs` will be dropped from the result.
+- `head xs` returns the first element of `xs` and `tail xs` returns all but the first element of `xs`. If `xs` is empty then there will be no result (similar to `observe false`).
+- `length xs` returns the length of `xs`.
+
+## Maximum list length
+
+The maximum list length `N` is a bound on the length of lists during execution of the program. If the final result is a list, then the probability distribution shown will be over all lists of length at most `N`.
+
+The maximum list length can be set with the command line flag `-max-list-length N`. `N` must be an integer which is at least 1. If not specified, it defaults to the recursion limit, which if not specified defaults to 10.

--- a/lib/ExternalGrammar.ml
+++ b/lib/ExternalGrammar.ml
@@ -9,6 +9,7 @@ type typ =
     TBool
   | TInt of int (* sz *)
   | TTuple of typ * typ
+  | TList of typ
   | TFunc of typ List.t * typ
 [@@deriving sexp_of]
 
@@ -64,6 +65,8 @@ type eexpr =
   | Iter of source * String.t * eexpr * int
   | True of source
   | False of source
+  | ListLit of source * eexpr List.t
+  | ListLitEmpty of source * typ
 [@@deriving sexp_of]
 
 type func = { name: String.t; args: arg List.t; return_type: typ option; body: eexpr}
@@ -111,6 +114,8 @@ let get_src e =
   | FuncCall(s, _, _) -> s
   | LeftShift(s, _, _) -> s
   | RightShift(s, _, _) -> s
+  | ListLit(s, _) -> s
+  | ListLitEmpty(s, _) -> s
 
 let gen_src =
   let gen_pos = { Lexing.dummy_pos with pos_fname = "<generated>" } in

--- a/lib/ExternalGrammar.ml
+++ b/lib/ExternalGrammar.ml
@@ -67,6 +67,10 @@ type eexpr =
   | False of source
   | ListLit of source * eexpr List.t
   | ListLitEmpty of source * typ
+  | Cons of source * eexpr * eexpr
+  | Head of source * eexpr
+  | Tail of source * eexpr
+  | Length of source * eexpr
 [@@deriving sexp_of]
 
 type func = { name: String.t; args: arg List.t; return_type: typ option; body: eexpr}
@@ -116,6 +120,10 @@ let get_src e =
   | RightShift(s, _, _) -> s
   | ListLit(s, _) -> s
   | ListLitEmpty(s, _) -> s
+  | Cons(s, _, _) -> s
+  | Head(s, _) -> s
+  | Tail(s, _) -> s
+  | Length(s, _) -> s
 
 let gen_src =
   let gen_pos = { Lexing.dummy_pos with pos_fname = "<generated>" } in

--- a/lib/Parser.mly
+++ b/lib/Parser.mly
@@ -11,7 +11,7 @@
 %token IF THEN ELSE TRUE FALSE IN INT
 %token SEMICOLON COMMA COLON
 %token LET OBSERVE FLIP LBRACE RBRACE FST SND FUN BOOL ITERATE
-%token LIST LBRACKET RBRACKET
+%token LIST LBRACKET RBRACKET CONS HEAD TAIL LENGTH
 
 %token <int>    INT_LIT
 %token <float>  FLOAT_LIT
@@ -24,6 +24,7 @@
 %left IFF
 %left XOR
 %left LTE GTE LT GT NEQ
+%right CONS
 %left PLUS MINUS EQUAL_TO LEFTSHIFT RIGHTSHIFT
 %left MULTIPLY DIVIDE MODULUS
 /* entry point */
@@ -73,6 +74,10 @@ expr:
     | delimited(LBRACKET, separated_nonempty_list(COMMA, expr), RBRACKET)
         { ListLit({startpos=$startpos; endpos=$endpos}, $1) }
     | LBRACKET RBRACKET typ_annot { ListLitEmpty({startpos=$startpos; endpos=$endpos}, $3) }
+    | expr CONS expr { Cons({startpos=$startpos; endpos=$endpos}, $1, $3) }
+    | HEAD expr { Head({startpos=$startpos; endpos=$endpos}, $2) }
+    | TAIL expr { Tail({startpos=$startpos; endpos=$endpos}, $2) }
+    | LENGTH expr { Length({startpos=$startpos; endpos=$endpos}, $2) }
 
 typ:
     | BOOL { TBool }

--- a/lib/Parser.mly
+++ b/lib/Parser.mly
@@ -11,6 +11,7 @@
 %token IF THEN ELSE TRUE FALSE IN INT
 %token SEMICOLON COMMA COLON
 %token LET OBSERVE FLIP LBRACE RBRACE FST SND FUN BOOL ITERATE
+%token LIST LBRACKET RBRACKET
 
 %token <int>    INT_LIT
 %token <float>  FLOAT_LIT
@@ -69,11 +70,15 @@ expr:
     | IF expr THEN expr ELSE expr { Ite({startpos=$startpos; endpos=$endpos}, $2, $4, $6) }
     | ITERATE LPAREN id=ID COMMA e=expr COMMA k=INT_LIT RPAREN { Iter({startpos=$startpos; endpos=$endpos}, id, e, k) }
     | LET ID EQUAL expr IN expr { Let({startpos=$startpos; endpos=$endpos}, $2, $4, $6) }
+    | delimited(LBRACKET, separated_nonempty_list(COMMA, expr), RBRACKET)
+        { ListLit({startpos=$startpos; endpos=$endpos}, $1) }
+    | LBRACKET RBRACKET typ_annot { ListLitEmpty({startpos=$startpos; endpos=$endpos}, $3) }
 
 typ:
     | BOOL { TBool }
     | INT LPAREN; sz=INT_LIT; RPAREN  { TInt(sz) }
     | LPAREN typ COMMA typ RPAREN { TTuple($2, $4) }
+    | LIST LPAREN typ RPAREN { TList($3) }
 
 typ_annot: COLON typ { $2 }
 

--- a/lib/Passes.ml
+++ b/lib/Passes.ml
@@ -4,6 +4,10 @@ open Util
 module EG = ExternalGrammar
 module CG = CoreGrammar
 
+type config = { max_list_length: int }
+
+let default_config = { max_list_length = 10 }
+
 let n = ref 0
 
 let fresh () =
@@ -49,6 +53,12 @@ let map_eexpr f =
   | Iter(s, fn, e, n) -> Iter(s, fn, f e, n)
   | True s -> True s
   | False s -> False s
+  | ListLit(s, es) -> ListLit(s, List.map es ~f)
+  | ListLitEmpty(s, t) -> ListLitEmpty(s, t)
+  | Cons(s, e1, e2) -> Cons(s, f e1, f e2)
+  | Head(s, e) -> Head(s, f e)
+  | Tail(s, e) -> Tail(s, f e)
+  | Length(s, e) -> Length(s, f e)
 
 let default_recursion_limit = 10
 
@@ -60,8 +70,9 @@ let rec gen_default_value =
   let open EG in
   function
   | TBool -> False gen_src
-  | TInt sz -> Int (gen_src, sz, 0)
-  | TTuple (t1, t2) -> Tup(gen_src, gen_default_value t1, gen_default_value t2)
+  | TInt sz -> Int(gen_src, sz, 0)
+  | TTuple(t1, t2) -> Tup(gen_src, gen_default_value t1, gen_default_value t2)
+  | TList t -> ListLitEmpty(gen_src, t)
   | TFunc _ -> failwith "Internal Error: gen_default_value called with function type"
 
 let expand_recursion ?(recursion_limit = default_recursion_limit) (p: EG.program) =
@@ -103,47 +114,12 @@ let inline_functions (p: EG.program) =
       Map.Poly.add_exn acc ~key:f.name ~data:f) in
   let rec helper (e: EG.eexpr) =
     match e with
-    | And(s, e1, e2) ->
-      let s1 = helper e1 in
-      let s2 = helper e2 in And(s, s1, s2)
-    | LeftShift(s, e1, i) ->
-      let s1 = helper e1 in LeftShift(s, s1, i)
-    | RightShift(s, e1, i) ->
-      let s1 = helper e1 in RightShift(s, s1, i)
-    | Or(s, e1, e2) ->
-      let s1 = helper e1 in
-      let s2 = helper e2 in Or(s, s1, s2)
-    | Sample(s, e1) -> Sample(s, helper e1)
     | Iff(s, e1, e2) ->
       let s1 = helper e1 in
       let s2 = helper e2 in Eq(s, s1, s2)
-    | Xor(s, e1, e2) ->
-      let s1 = helper e1 in
-      let s2 = helper e2 in Xor(s, s1, s2)
-    | IntConst(_, _) -> e
-    | Plus(s, e1, e2) -> Plus(s, helper e1, helper e2)
-    | Eq(s, e1, e2) -> Eq(s, helper e1, helper e2)
-    | Neq(s, e1, e2) -> Neq(s, helper e1, helper e2)
-    | Minus(s, e1, e2) -> Minus(s, helper e1, helper e2)
-    | Mult(s, e1, e2) -> Mult(s, helper e1, helper e2)
-    | Div(s, e1, e2) -> Div(s, helper e1, helper e2)
-    | Lt(s, e1, e2) -> Lt(s, helper e1, helper e2)
     | Lte(s, e1, e2) -> helper(Or(s, Lt(s, e1, e2), Eq(s, e1, e2)))
     | Gt(s, e1, e2) -> helper(Not(s, Lte(s, e1, e2)))
     | Gte(s, e1, e2) -> helper(Not(s, Lt(s, e1, e2)))
-    | Not(s, e) -> Not(s, helper e)
-    | Flip(s, f) -> Flip(s, f)
-    | Ident(s, id) -> Ident(s, id)
-    | Discrete(s, l) -> Discrete(s, l)
-    | Int(s, sz, v) -> Int(s, sz, v)
-    | True(s) -> True(s)
-    | False(s) -> False(s)
-    | Observe(s, e) -> Observe(s, helper e)
-    | Let(s, x, e1, e2) -> Let(s, x, helper e1, helper e2)
-    | Ite(s, g, thn, els) -> Ite(s, helper g, helper thn, helper els)
-    | Snd(s, e) -> Snd(s, helper e)
-    | Fst(s, e) -> Fst(s, helper e)
-    | Tup(s, e1, e2) -> Tup(s, helper e1, helper e2)
     | Iter(s, f, init, k) -> helper (expand_iter s f init k)
     | FuncCall(s, "nth_bit", args) ->
       FuncCall(s, "nth_bit", List.map args ~f:helper)
@@ -151,7 +127,8 @@ let inline_functions (p: EG.program) =
       let cur_f = try Map.Poly.find_exn function_map id
         with _ -> failwith (Format.sprintf "Internal error: could not find inlined function %s" id) in
       let inlined = helper cur_f.body in
-      List.fold (List.zip_exn cur_f.args args) ~init:inlined ~f:(fun acc (arg, v) -> Let(s, fst arg, v, acc)) in
+      List.fold (List.zip_exn cur_f.args args) ~init:inlined ~f:(fun acc (arg, v) -> Let(s, fst arg, v, acc))
+    | _ -> map_eexpr helper e in
   {functions=[]; body=helper p.body}
 
 let num_paths (p: EG.program) : LogProbability.t =
@@ -171,23 +148,24 @@ let num_paths (p: EG.program) : LogProbability.t =
     | Lte(_,e1, e2)
     | Gte(_,e1, e2)
     | Tup(_,e1, e2)
-    | Let(_,_, e1, e2) ->
+    | Let(_,_, e1, e2)
+    | Cons(_, e1, e2) ->
       let s1 = helper e1 in
       let s2 = helper e2 in LogProbability.mult s1 s2
     | Not(_,e) -> helper e
     | Flip(_,_) -> LogProbability.make 2.0
-    | Ident(_,_) ->  LogProbability.make 1.0
+    | Ident(_,_) | Int(_,_, _) | True(_) | False(_) | ListLitEmpty(_, _) ->
+      LogProbability.make 1.0
     | Discrete(_,l) -> LogProbability.make (float_of_int (List.length l))
-    | Int(_,_, _) -> LogProbability.make 1.0
-    | True(_) -> LogProbability.make 1.0
-    | False(_) -> LogProbability.make 1.0
     | Observe(_,e) -> helper e
     | Ite(_,g, thn, els) ->
       let gc = helper g in
       let tc = helper thn in
       let ec = helper els in
       LogProbability.mult gc (LogProbability.add tc ec)
-    | Snd(_,e) | Fst(_, e) -> helper e
+    | Snd(_,e) | Fst(_, e)
+    | Head(_, e) | Tail(_, e) | Length(_, e) -> helper e
+    | ListLit(_, es) -> List.reduce_exn (List.map es ~f:helper) ~f:LogProbability.mult
     | _ -> failwith "unreachable, functions inlined" in
   helper inlined.body
 
@@ -239,6 +217,8 @@ let rec mk_dfs_tuple l =
   | x::xs ->
     CG.Tup(x, mk_dfs_tuple xs)
 
+let bit_length x = Int.floor_log2 x + 1
+
 let rec type_eq t1 t2 =
   let open EG in
   match (t1, t2) with
@@ -246,6 +226,7 @@ let rec type_eq t1 t2 =
   | ((TTuple(ll, lr), TTuple(rl, rr))) ->
     (type_eq ll rl) && (type_eq lr rr)
   | (TInt(d1), TInt(d2)) when d1 = d2 -> true
+  | TList l, TList r -> type_eq l r
   | _ -> false
 
 type source = EG.source
@@ -285,6 +266,12 @@ type ast =
   | Iter of source * String.t * tast * int
   | True of source
   | False of source
+  | ListLit of source * tast List.t
+  | ListLitEmpty of source
+  | Cons of source * tast * tast
+  | Head of source * tast
+  | Tail of source * tast
+  | Length of source * tast
 and
   tast = EG.typ * ast
 [@@deriving sexp_of]
@@ -306,20 +293,29 @@ type typ_ctx = { in_func: bool }
 let get_col (pos: EG.lexing_position) =
   pos.pos_cnum - pos.pos_bol
 
-let rec type_of (ctx: typ_ctx) (env: EG.tenv) (e: EG.eexpr) : tast =
+let rec type_of (cfg: config) (ctx: typ_ctx) (env: EG.tenv) (e: EG.eexpr) : tast =
   let open EG in
   let expect_t e (src: EG.lexing_position) typ : tast =
-    let (t, e) = type_of ctx env e in
+    let (t, e) = type_of cfg ctx env e in
     if (type_eq t typ) then (t, e) else
       raise (EG.Type_error(Format.sprintf "Type error at line %d column %d: expected %s, got %s"
                                       src.pos_lnum (get_col src) (EG.string_of_typ typ) (EG.string_of_typ t))) in
+  let expect_t' typ e = expect_t e (get_src e).startpos typ in
   let expect_compatible_int (f: tast -> tast -> ast) src e1 e2 lbl =
-    let (t1, s1) = type_of ctx env e1 and (t2, s2) = type_of ctx env e2 in
+    let (t1, s1) = type_of cfg ctx env e1 and (t2, s2) = type_of cfg ctx env e2 in
     match (t1, t2) with
     | (TInt(d1), TInt(d2)) when d1 = d2 -> (d1, f (t1, s1) (t1, s2))
     | (_, _) ->
       raise (EG.Type_error(Format.sprintf "Type error at line %d column %d: expected compatible integer types for operation '%s', got %s and %s"
                              src.pos_lnum (get_col src) lbl (EG.string_of_typ t1) (EG.string_of_typ t2)))  in
+  let expect_list e : typ * tast =
+    let (t, e') = type_of cfg ctx env e in
+    match t with
+    | TList t' -> (t', (t, e'))
+    | _ ->
+      let pos = (get_src e).startpos in
+      raise (Type_error (Format.sprintf "Type error at line %d column %d: expected a list type, got %s"
+                          pos.pos_lnum (get_col pos) (string_of_typ t))) in
   match e with
   | And(s, e1, e2) ->
     let s1 = expect_t e1 s.startpos TBool in
@@ -338,7 +334,7 @@ let rec type_of (ctx: typ_ctx) (env: EG.tenv) (e: EG.eexpr) : tast =
       raise (Type_error (Format.sprintf "Type error at line %d column %d: \
                                          Sampling within functions is not permitted"
                            s.startpos.pos_lnum (get_col s.startpos)));
-    let t, e = type_of ctx (Map.Poly.empty) e1 in
+    let t, e = type_of cfg ctx (Map.Poly.empty) e1 in
     (t, Sample(s, (t, e)))
   | Xor(s, e1, e2) ->
     let s1 = expect_t e1 s.startpos TBool in
@@ -360,22 +356,22 @@ let rec type_of (ctx: typ_ctx) (env: EG.tenv) (e: EG.eexpr) : tast =
                                     src.startpos.pos_lnum (get_col src.startpos) s))) in
     (t, Ident(src, s))
   | Fst(s, e1) ->
-    let (t, s1) = type_of ctx env e1 in
+    let (t, s1) = type_of cfg ctx env e1 in
     let t' = (match t with
      | TTuple(l, _) -> l
      | t -> raise (Type_error (Format.sprintf "Type error at line %d column %d: expected tuple, got %s"
                                  s.startpos.pos_lnum (get_col s.startpos) (string_of_typ t)))) in
     (t', Fst(s, (t, s1)))
   | Snd(s, e1) ->
-    let s1 = type_of ctx env e1 in
+    let s1 = type_of cfg ctx env e1 in
     let t = (match fst s1 with
      | TTuple(_, r) -> r
      | t -> raise (Type_error (Format.sprintf "Type error at line %d column %d: expected tuple, got %s"
                                  s.startpos.pos_lnum (get_col s.startpos) (string_of_typ t)))) in
     (t, Snd(s, s1))
   | Tup(s, e1, e2) ->
-    let t1 = type_of ctx env e1 in
-    let t2 = type_of ctx env e2 in
+    let t1 = type_of cfg ctx env e1 in
+    let t2 = type_of cfg ctx env e2 in
     (TTuple(fst t1, fst t2), Tup(s, t1, t2))
   | Int(src, sz, v) ->
     if v >= 1 lsl sz then
@@ -389,10 +385,10 @@ let rec type_of (ctx: typ_ctx) (env: EG.tenv) (e: EG.eexpr) : tast =
                            src.startpos.pos_lnum (get_col src.startpos) sum))
     else (TInt(num_binary_digits ((List.length l) - 1)), Discrete(src, l))
   | LeftShift(s, e1, i) ->
-    let (t, e) = type_of ctx env e1 in
+    let (t, e) = type_of cfg ctx env e1 in
     (t, LeftShift(s, (t, e), i))
   | RightShift(s, e1, i) ->
-    let (t, e) = type_of ctx env e1 in
+    let (t, e) = type_of cfg ctx env e1 in
     (t, RightShift(s, (t, e), i))
   | Eq(s, e1, e2) -> (TBool, snd (expect_compatible_int (fun s1 s2 -> Eq(s, s1, s2)) s.startpos e1 e2 "="))
   | Lt(s, e1, e2) -> (TBool, snd (expect_compatible_int (fun e1 e2 -> Lt(s, e1, e2)) s.startpos e1 e2 "<"))
@@ -413,19 +409,19 @@ let rec type_of (ctx: typ_ctx) (env: EG.tenv) (e: EG.eexpr) : tast =
     let sz, res = expect_compatible_int (fun e1 e2 -> Div(s, e1, e2)) s.startpos e1 e2 "/" in
     (TInt(sz), res)
   | Let(slet, x, e1, e2) ->
-    let r1 = type_of ctx env e1 in
-    let r2 = type_of ctx (Map.Poly.set env ~key:x ~data:(fst r1)) e2 in
+    let r1 = type_of cfg ctx env e1 in
+    let r2 = type_of cfg ctx (Map.Poly.set env ~key:x ~data:(fst r1)) e2 in
     (fst r2, Let(slet, x, r1, r2))
   | Ite(s, g, thn, els) ->
     let sg = expect_t g ((EG.get_src g).startpos) TBool in
-    let (t1, thnbody) = type_of ctx env thn and (t2, elsbody) = type_of ctx env els in
+    let (t1, thnbody) = type_of cfg ctx env thn and (t2, elsbody) = type_of cfg ctx env els in
     if not (type_eq t1 t2) then
       raise (Type_error (Format.sprintf "Type error at line %d column %d: expected equal types \
                                          from branches of if-statement, got %s and %s"
                            s.startpos.pos_lnum (get_col s.startpos) (string_of_typ t1) (string_of_typ t2)))
     else (t1, Ite(s, sg, (t1, thnbody), (t2, elsbody)))
   | FuncCall(s, "nth_bit", [Int(src, sz, v); e2]) ->
-    let conve2 = match type_of ctx env e2 with
+    let conve2 = match type_of cfg ctx env e2 with
       | (TInt(v), r) ->(TInt(v), r)
       | _ -> raise (Type_error (Format.sprintf "Type error at line %d column %d: expected int for second argument"
                                   s.startpos.pos_lnum (get_col s.startpos))) in
@@ -445,7 +441,7 @@ let rec type_of (ctx: typ_ctx) (env: EG.tenv) (e: EG.eexpr) : tast =
                                                    %d arguments and got %d arguments"
                                      s.startpos.pos_lnum (get_col s.startpos) (List.length targ) (List.length args))) in
     let arg' = List.mapi zipped ~f:(fun idx (arg, typ) ->
-        let (found_t, body) = type_of ctx env arg in
+        let (found_t, body) = type_of cfg ctx env arg in
         if (type_eq found_t typ) then (found_t, body) else
           raise (Type_error (Format.sprintf "Type error in argument %d at line %d column %d: expected type %s, got %s"
                                s.startpos.pos_lnum (get_col s.startpos) (idx + 1) (string_of_typ typ) (string_of_typ found_t)))
@@ -462,10 +458,31 @@ let rec type_of (ctx: typ_ctx) (env: EG.tenv) (e: EG.eexpr) : tast =
         | _ -> raise (Type_error (Format.sprintf "Type error at line %d column %d: non-function type found for \
                                                    '%s' during typechecking, found %s "
                                      (get_col s.startpos) (get_col s.startpos) id (string_of_typ res)))) in
-    let init' = type_of ctx env init in
+    let init' = type_of cfg ctx env init in
     (* TODO check arg validity*)
     (tres, Iter(s, id, init', k))
-
+  | ListLit(s, e1 :: es) ->
+    let (t, e1') = type_of cfg ctx env e1 in
+    (TList t, ListLit(s, (t, e1') :: List.map es ~f:(expect_t' t)))
+  | ListLit(_, []) -> failwith "empty ListLit"
+  | ListLitEmpty(s, t) ->
+    begin match t with
+    | TList _ -> (t, ListLitEmpty s)
+    | _ -> raise (Type_error (Format.sprintf "Type error at line %d column %d: empty list must have a list type"
+                                s.startpos.pos_lnum (get_col s.startpos)))
+    end
+  | Cons(s, e1, e2) ->
+    let (t, e1') = type_of cfg ctx env e1 in
+    (TList t, Cons(s, (t, e1'), expect_t' (TList t) e2))
+  | Head(s, e) ->
+    let (t, tast) = expect_list e in
+    (t, Head(s, tast))
+  | Tail(s, e) ->
+    let (_, (t, e')) = expect_list e in
+    (t, Tail(s, (t, e')))
+  | Length(s, e) ->
+    let (_, tast) = expect_list e in
+    (TInt (bit_length cfg.max_list_length), Length(s, tast))
 
 let rec expand_iter_t s f ((t, curv):tast) k : tast =
   assert (k >= 0);
@@ -722,13 +739,13 @@ let rec from_external_expr_h (ctx: external_ctx) (tenv: EG.tenv) ((t, e): tast) 
   | Sample(_, e) -> Sample(from_external_expr_h ctx tenv e)
   | IntConst(_, _) -> failwith "not implemented"
 
-let from_external_expr mgr in_func (env: EG.tenv) (e: EG.eexpr) : (EG.typ * CG.expr) =
+let from_external_expr mgr cfg in_func (env: EG.tenv) (e: EG.eexpr) : (EG.typ * CG.expr) =
   let ctx = if in_func then {in_func=true} else {in_func=false} in
-  let (typ, e) = type_of ctx env e in
+  let (typ, e) = type_of cfg ctx env e in
   let r = (typ, from_external_expr_h mgr Map.Poly.empty (typ, e)) in
   r
 
-let rec from_external_typ (t:EG.typ) : CG.typ =
+let rec from_external_typ cfg (t:EG.typ) : CG.typ =
   match t with
     TBool -> TBool
   | TInt(sz) ->
@@ -741,12 +758,15 @@ let rec from_external_typ (t:EG.typ) : CG.typ =
       | [] -> failwith "Internal Error: Invalid int type"
     in
     mk_dfs_typ l
-  | TTuple(t1, t2) -> TTuple(from_external_typ t1, from_external_typ t2)
+  | TTuple(t1, t2) -> TTuple(from_external_typ cfg t1, from_external_typ cfg t2)
+  | TList t -> from_external_typ cfg @@
+    TTuple(TInt(bit_length cfg.max_list_length),
+           Fn.apply_n_times ~n:(cfg.max_list_length - 1) (fun t' -> EG.TTuple(t, t')) t)
   | _ -> failwith "Internal Error: unreachable"
 
-let from_external_arg (a:EG.arg) : CG.arg =
+let from_external_arg cfg (a:EG.arg) : CG.arg =
   let (name, t) = a in
-  (name, from_external_typ t)
+  (name, from_external_typ cfg t)
 
 let check_return_type (f: EG.func) (t : EG.typ) : unit =
   let open EG in
@@ -759,50 +779,50 @@ let check_return_type (f: EG.func) (t : EG.typ) : unit =
                        f.name (string_of_typ t)))
   | _ -> ()
 
-let from_external_func mgr (tenv: EG.tenv) (f: EG.func) : (EG.typ * CG.func) =
+let from_external_func mgr cfg (tenv: EG.tenv) (f: EG.func) : (EG.typ * CG.func) =
   (* add the arguments to the type environment *)
   let tenvwithargs = List.fold f.args ~init:tenv ~f:(fun acc (name, typ) ->
       Map.Poly.set acc ~key:name ~data:typ
     ) in
-  let (t, conv) = from_external_expr mgr true tenvwithargs f.body in
+  let (t, conv) = from_external_expr mgr cfg true tenvwithargs f.body in
   check_return_type f t;
   (* convert arguments *)
-  let args = List.map f.args ~f:from_external_arg in
+  let args = List.map f.args ~f:(from_external_arg cfg) in
   (TFunc(List.map f.args ~f:snd, t), {name = f.name;
        args = args;
        body = conv})
 
-let from_external_func_optimize mgr (tenv: EG.tenv) (f: EG.func) (flip_lifting: bool) (branch_elimination: bool) (determinism: bool) : (EG.typ * CG.func) =
+let from_external_func_optimize mgr cfg (tenv: EG.tenv) (f: EG.func) (flip_lifting: bool) (branch_elimination: bool) (determinism: bool) : (EG.typ * CG.func) =
   (* add the arguments to the type environment *)
   let tenvwithargs = List.fold f.args ~init:tenv ~f:(fun acc (name, typ) ->
       Map.Poly.set acc ~key:name ~data:typ
     ) in
-  let (t, conv) = from_external_expr mgr true tenvwithargs f.body in
+  let (t, conv) = from_external_expr mgr cfg true tenvwithargs f.body in
   check_return_type f t;
   let optbody = Optimization.do_optimize conv !n flip_lifting branch_elimination determinism in
   (* convert arguments *)
-  let args = List.map f.args ~f:from_external_arg in
+  let args = List.map f.args ~f:(from_external_arg cfg) in
   (TFunc(List.map f.args ~f:snd, t), {name = f.name;
         args = args;
         body = optbody})
 
-let from_external_prog (p: EG.program) : (EG.typ * CG.program) =
+let from_external_prog ?(cfg: config = default_config) (p: EG.program) : (EG.typ * CG.program) =
   let mgr = Cudd.Man.make_d () in
   let (tenv, functions) = List.fold p.functions ~init:(Map.Poly.empty, []) ~f:(fun (tenv, flst) i ->
-      let (t, conv) = from_external_func mgr tenv i in
+      let (t, conv) = from_external_func mgr cfg tenv i in
       let tenv' = Map.Poly.set tenv ~key:i.name ~data:t in
       (tenv', flst @ [conv])
     ) in
-  let (t, convbody) = from_external_expr mgr false tenv p.body in
+  let (t, convbody) = from_external_expr mgr cfg false tenv p.body in
   (t, {functions = functions; body = convbody})
 
-  let from_external_prog_optimize (p: EG.program) (flip_lifting: bool) (branch_elimination: bool) (determinism: bool) : (EG.typ * CG.program) =
+  let from_external_prog_optimize ?(cfg: config = default_config) (p: EG.program) (flip_lifting: bool) (branch_elimination: bool) (determinism: bool) : (EG.typ * CG.program) =
     let mgr = Cudd.Man.make_d () in
     let (tenv, functions) = List.fold p.functions ~init:(Map.Poly.empty, []) ~f:(fun (tenv, flst) i ->
-        let (t, conv) = from_external_func_optimize mgr tenv i flip_lifting branch_elimination determinism in
+        let (t, conv) = from_external_func_optimize mgr cfg tenv i flip_lifting branch_elimination determinism in
         let tenv' = Map.Poly.set tenv ~key:i.name ~data:t in
         (tenv', flst @ [conv])
       ) in
-    let (t, convbody) = from_external_expr mgr false tenv p.body in
+    let (t, convbody) = from_external_expr mgr cfg false tenv p.body in
     let optbody = Optimization.do_optimize convbody !n flip_lifting branch_elimination determinism in
     (t, {functions = functions; body = optbody})

--- a/lib/Passes.ml
+++ b/lib/Passes.ml
@@ -217,8 +217,6 @@ let rec mk_dfs_tuple l =
   | x::xs ->
     CG.Tup(x, mk_dfs_tuple xs)
 
-let bit_length x = Int.floor_log2 x + 1
-
 let rec type_eq t1 t2 =
   let open EG in
   match (t1, t2) with

--- a/lib/Passes.mli
+++ b/lib/Passes.mli
@@ -3,6 +3,8 @@
 
 type config = { max_list_length: int }
 
+val default_config : config
+
 val expand_recursion : ?recursion_limit:int -> ExternalGrammar.program -> ExternalGrammar.program
 
 (** Inline all function calls *)

--- a/lib/Passes.mli
+++ b/lib/Passes.mli
@@ -1,6 +1,8 @@
 (** Passes over the external and internal grammar.
   * Implementations of syntactic sugar, optimizations, etc. *)
 
+type config = { max_list_length: int }
+
 val expand_recursion : ?recursion_limit:int -> ExternalGrammar.program -> ExternalGrammar.program
 
 (** Inline all function calls *)
@@ -10,6 +12,6 @@ val inline_functions : ExternalGrammar.program -> ExternalGrammar.program
   * Note: assumes that function calls are inlined, no iteration *)
 val num_paths : ExternalGrammar.program -> LogProbability.t
 
-val from_external_prog: ExternalGrammar.program -> (ExternalGrammar.typ * CoreGrammar.program)
+val from_external_prog: ?cfg:config -> ExternalGrammar.program -> (ExternalGrammar.typ * CoreGrammar.program)
 
-val from_external_prog_optimize: ExternalGrammar.program -> bool -> bool -> bool -> (ExternalGrammar.typ * CoreGrammar.program)
+val from_external_prog_optimize: ?cfg:config -> ExternalGrammar.program -> bool -> bool -> bool -> (ExternalGrammar.typ * CoreGrammar.program)

--- a/lib/Util.ml
+++ b/lib/Util.ml
@@ -13,6 +13,8 @@ let within_epsilon x y =
 
 let log2 a = log a /. (log 2.0)
 
+let bit_length x = Int.floor_log2 x + 1
+
 (** [dir_contents] returns the paths of all regular files that are
  * contained in [dir]. Each file is a path starting with [dir].
   *)

--- a/lib/Util.mli
+++ b/lib/Util.mli
@@ -10,5 +10,7 @@ val dir_contents: string -> string List.t
 
 val log2 : float -> float
 
+val bit_length : int -> int
+
 (** true if the two arguments are very close to each other (TODO avoid using this with rationals )*)
 val within_epsilon : float -> float -> bool

--- a/lib/VarState.mli
+++ b/lib/VarState.mli
@@ -15,9 +15,9 @@ val zip_tree : 'a btree -> 'b btree -> ('a * 'b) btree
 val extract_leaf : 'a btree -> 'a
 
 (** [get_table] gets a list of all possible instantiations of BDDs in [st]. *)
-val get_table: Bdd.dt btree ->
+val get_table: Passes.config -> Bdd.dt btree ->
   ExternalGrammar.typ ->
-  (([> `False | `Int of int | `True | `Tup of 'a * 'a ] as 'a) *  Cudd.Man.d Cudd.Bdd.t) list
+  (([> `False | `Int of int | `True | `Tup of 'a * 'a | `List of 'a list ] as 'a) *  Cudd.Man.d Cudd.Bdd.t) list
 
 (** [state_size] computes the total number of unique nodes in the list of
     varstates [states] *)

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -39,6 +39,7 @@ rule token =
     | '!'                       { NOT }
     | "int"                     { INT }
     | "bool"                    { BOOL }
+    | "list"                    { LIST }
     | "<="                      { LTE }
     | ">="                      { GTE }
     | "=="                      { EQUAL_TO }
@@ -66,6 +67,8 @@ rule token =
     | "fun"                     { FUN }
     | '('                       { LPAREN }
     | ')'                       { RPAREN }
+    | '['                       { LBRACKET }
+    | ']'                       { RBRACKET }
     | '{'                       { LBRACE }
     | '}'                       { RBRACE }
     | ';'                       { SEMICOLON }

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -49,6 +49,7 @@ rule token =
     | "!="                      { NEQ }
     | "&&"                      { AND }
     | "||"                      { OR }
+    | "::"                      { CONS }
     | "//"                      { comment lexbuf; }
     | "if"                      { IF }
     | "sample"                  { SAMPLE }
@@ -65,6 +66,9 @@ rule token =
     | "observe"                 { OBSERVE }
     | "flip"                    { FLIP }
     | "fun"                     { FUN }
+    | "head"                    { HEAD }
+    | "tail"                    { TAIL }
+    | "length"                  { LENGTH }
     | '('                       { LPAREN }
     | ')'                       { RPAREN }
     | '['                       { LBRACKET }

--- a/resources/list-distribution.dice
+++ b/resources/list-distribution.dice
@@ -1,0 +1,10 @@
+fun build(n: int(2)): list(bool) {
+    if n == int(2, 0) then
+        ([] : list(bool))
+    else if flip 0.5 then
+        flip 0.2 :: build(n - int(2, 1))
+    else
+        build(n - int(2, 1))
+}
+
+build(int(2, 3))

--- a/resources/list-ex.dice
+++ b/resources/list-ex.dice
@@ -1,0 +1,2 @@
+let xs = [flip 0.2, flip 0.4] in
+if flip 0.5 then (head xs) :: xs else tail xs

--- a/resources/list-index.dice
+++ b/resources/list-index.dice
@@ -1,0 +1,9 @@
+fun index(n: int(2), xs: list(bool)): bool {
+    if n == int(2, 0) then
+        head xs
+    else
+        index(n - int(2, 1), tail xs)
+}
+
+let xs = [true, false, false] in
+[index(int(2, 2), xs), index(int(2, 1), xs), index(int(2, 0), xs)]

--- a/test/Test.ml
+++ b/test/Test.ml
@@ -573,6 +573,84 @@ let test_fibonacci _ =
   assert_feq 1.0 (parse_and_prob prog);
   assert_feq 1.0 (parse_optimize_and_prob prog)
 
+let test_list _ =
+  let prog = "
+    let xs = [true, false, false] in
+    (head xs) && !(head (tail xs)) && !(head (tail (tail xs)))
+  " in
+  assert_feq 1.0 (parse_and_prob prog);
+  assert_feq 1.0 (parse_optimize_and_prob prog)
+
+let test_length _ =
+  let prog = "
+    let xs = [true, false, false] in
+    (length xs) == int(4, 3)
+  " in
+  assert_feq 1.0 (parse_and_prob prog);
+  assert_feq 1.0 (parse_optimize_and_prob prog)
+
+let test_empty _ =
+  let prog = "
+    let xs = [] : list(bool) in
+    (length xs) == int(4, 0)
+  " in
+  assert_feq 1.0 (parse_and_prob prog);
+  assert_feq 1.0 (parse_optimize_and_prob prog)
+
+let test_list_recursion _ =
+  let prog = "
+    fun index(n: int(2), xs: list(bool)): bool {
+      if n == int(2, 0) then
+        head xs
+      else
+        index(n - int(2, 1), tail xs)
+    }
+    let xs = [true, false, false] in
+    !index(int(2, 2), xs) && !index(int(2, 1), xs) && index(int(2, 0), xs)
+  " in
+  assert_feq 1.0 (parse_and_prob prog);
+  assert_feq 1.0 (parse_optimize_and_prob prog)
+
+let test_list_distribution _ =
+  let prog = "
+    fun build(n: int(2)): list(bool) {
+      if n == int(2, 0) then
+        ([] : list(bool))
+      else if flip 0.5 then
+        flip 0.2 :: build(n - int(2, 1))
+      else
+        build(n - int(2, 1))
+    }
+    let xs = build(int(2, 3)) in
+    " in
+  let test prob expr =
+    assert_feq prob (parse_and_prob (prog ^ expr));
+    assert_feq prob (parse_optimize_and_prob (prog ^ expr)) in
+  test (0.5 *. 0.5 *. 0.5) "(length xs) == int(4, 0)";
+  test (0.5 *. 0.2 *. 0.5 *. 0.5 *. 3.) "if (length xs) == int(4, 1) then (head xs) else false";
+  test (0.5 *. 0.8 *. 0.5 *. 0.5 *. 3.) "if (length xs) == int(4, 1) then !(head xs) else false";
+  test (0.5 *. 0.2 *. 0.5 *. 0.2 *. 0.5 *. 3.) "if (length xs) == int(4, 2) then (head xs) && (head (tail xs)) else false";
+  test (0.5 *. 0.2 *. 0.5 *. 0.8 *. 0.5 *. 3.) "if (length xs) == int(4, 2) then (head xs) && !(head (tail xs)) else false";
+  test (0.5 *. 0.8 *. 0.5 *. 0.2 *. 0.5 *. 3.) "if (length xs) == int(4, 2) then !(head xs) && (head (tail xs)) else false";
+  test (0.5 *. 0.8 *. 0.5 *. 0.8 *. 0.5 *. 3.) "if (length xs) == int(4, 2) then !(head xs) && !(head (tail xs)) else false";
+  test (0.5 *. 0.2 *. 0.5 *. 0.2 *. 0.5 *. 0.2) "if (length xs) == int(4, 3) then (head xs) && (head (tail xs)) && (head (tail (tail xs))) else false";
+  test (0.5 *. 0.2 *. 0.5 *. 0.2 *. 0.5 *. 0.8) "if (length xs) == int(4, 3) then (head xs) && (head (tail xs)) && !(head (tail (tail xs))) else false";
+  test (0.5 *. 0.2 *. 0.5 *. 0.8 *. 0.5 *. 0.2) "if (length xs) == int(4, 3) then (head xs) && !(head (tail xs)) && (head (tail (tail xs))) else false";
+  test (0.5 *. 0.2 *. 0.5 *. 0.8 *. 0.5 *. 0.8) "if (length xs) == int(4, 3) then (head xs) && !(head (tail xs)) && !(head (tail (tail xs))) else false";
+  test (0.5 *. 0.8 *. 0.5 *. 0.2 *. 0.5 *. 0.2) "if (length xs) == int(4, 3) then !(head xs) && (head (tail xs)) && (head (tail (tail xs))) else false";
+  test (0.5 *. 0.8 *. 0.5 *. 0.2 *. 0.5 *. 0.8) "if (length xs) == int(4, 3) then !(head xs) && (head (tail xs)) && !(head (tail (tail xs))) else false";
+  test (0.5 *. 0.8 *. 0.5 *. 0.8 *. 0.5 *. 0.2) "if (length xs) == int(4, 3) then !(head xs) && !(head (tail xs)) && (head (tail (tail xs))) else false";
+  test (0.5 *. 0.8 *. 0.5 *. 0.8 *. 0.5 *. 0.8) "if (length xs) == int(4, 3) then !(head xs) && !(head (tail xs)) && !(head (tail (tail xs))) else false"
+
+let test_list_ex _ =
+  let prog = "
+    let xs = [flip 0.2, flip 0.4] in
+    let ys = if flip 0.5 then (head xs) :: xs else tail xs in
+    head ys
+  " in
+  assert_feq (0.2 *. 0.5 +. 0.4 *. 0.5) (parse_and_prob prog);
+  assert_feq (0.2 *. 0.5 +. 0.4 *. 0.5) (parse_optimize_and_prob prog)
+
 let expression_tests =
 "suite">:::
 [
@@ -672,6 +750,13 @@ let expression_tests =
   "test_caesar_recursive">::test_caesar_recursive;
   "test_factorial">::test_factorial;
   "test_fibonacci">::test_fibonacci;
+
+  "test_list">::test_list;
+  "test_length">::test_length;
+  "test_empty">::test_empty;
+  "test_list_recursion">::test_list_recursion;
+  "test_list_distribution">::test_list_distribution;
+  "test_list_ex">::test_list_ex;
 ]
 
 let () =


### PR DESCRIPTION
Added:
- List type: `list(t)`
- Empty list literal: `[] : list(t)`
- Nonempty list literal: `[x, y, z]`
- Cons: `x :: xs`
- Head: `head xs`
- Tail: `tail xs`
- Length: `length xs`

Lists are represented as a pair `(len, elems)` where `len` is an int large enough to hold the maximum list size (which is also the return type of `length`) and `elems` is a nested tuple of the elements. If there are less elements than the maximum list size then the remaining space will be filled with values whose bits are all 0. For instance `[true, false, true]` when max list size is 5 will be represented as `(int(3, 3), (true, (false, (true, (false, false)))))`.

A command line flag `-max-list-length` has been added which is optional and defaults to the recursion limit.

Also added some documentation and tests.