### PR TITLE
Add rational support + arbitrary inference

### DIFF
--- a/bin/dice.ml
+++ b/bin/dice.ml
@@ -60,7 +60,7 @@ let parse_and_print ~print_parsed ~print_internal ~print_size ~skip_table
     ~inline_functions ~sample_amount ~show_recursive_calls
     ~flip_lifting ~branch_elimination ~determinism ~print_state_bdd
     ~show_function_size ~print_unparsed ~print_function_bdd
-    ~recursion_limit ~max_list_length ~eager_eval
+    ~recursion_limit ~max_list_length ~eager_eval ~float_wmc
     lexbuf : result List.t = try
   let parsed = Compiler.parse_with_error lexbuf in
   let res = if print_parsed then [StringRes("Parsed program", (ExternalGrammar.string_of_prog parsed))] else [] in
@@ -84,14 +84,14 @@ let parse_and_print ~print_parsed ~print_internal ~print_size ~skip_table
     let compiled = Compiler.compile_program internal ~eager_eval in
     let zbdd = compiled.body.z in
     let res = if skip_table then res else res @
-       (let z = Wmc.wmc compiled.ctx.man zbdd compiled.ctx.weights in
+       (let z = Wmc.wmc ~float_wmc compiled.ctx.man zbdd compiled.ctx.weights in
        let table = VarState.get_table cfg compiled.ctx.man compiled.body.state t in
        let probs = List.map table ~f:(fun (label, bdd) ->
-           if Util.within_epsilon z 0.0 then (label, 0.0) else
-             let prob = (Wmc.wmc compiled.ctx.man (Bdd.bdd_and compiled.ctx.man bdd zbdd) compiled.ctx.weights) /. z in
+           if Bignum.(z = zero) then (label, Bignum.zero) else
+             let prob = Bignum.((Wmc.wmc ~float_wmc compiled.ctx.man (Bdd.bdd_and compiled.ctx.man bdd zbdd) compiled.ctx.weights) / z) in
              (label, prob)) in
        let l = [["Value"; "Probability"]] @
-         List.map probs ~f:(fun (typ, prob) -> [print_pretty typ; string_of_float prob]) in
+         List.map probs ~f:(fun (typ, prob) -> [print_pretty typ; Bignum.to_string_hum prob]) in
        [TableRes("Joint Distribution", l)]
       ) in
     (* let res = if show_recursive_calls then res @ [StringRes("Number of recursive calls",
@@ -180,6 +180,7 @@ let command =
      and eager_eval = flag "-eager-eval" no_arg ~doc:" eager let compilation"
      and recursion_limit = flag "-recursion-limit" (optional int) ~doc:" maximum recursion depth"
      and max_list_length = flag "-max-list-length" (optional int) ~doc:" maximum list length"
+     and float_wmc = flag "-float-wmc" no_arg ~doc:" use float-based wmc"
      (* and print_marginals = flag "-show-marginals" no_arg ~doc:" print the marginal probabilities of a tuple in depth-first order" *)
      and json = flag "-json" no_arg ~doc:" print output as JSON"
      in fun () ->
@@ -190,7 +191,7 @@ let command =
                   ~print_size ~inline_functions ~skip_table ~flip_lifting
                   ~branch_elimination ~determinism ~show_recursive_calls ~print_state_bdd
                   ~show_function_size ~print_unparsed ~print_function_bdd
-                  ~recursion_limit ~max_list_length ~eager_eval
+                  ~recursion_limit ~max_list_length ~eager_eval ~float_wmc
                   lexbuf) in
        if json then Format.printf "%s" (Yojson.to_string (`List(List.map r ~f:json_res)))
        else List.iter r ~f:print_res

--- a/bin/dune
+++ b/bin/dune
@@ -1,5 +1,5 @@
 (executable
- (libraries core cudd sexplib menhirLib diceLib yojson)
+ (libraries core cudd sexplib menhirLib diceLib yojson bignum)
  (name dice)
  (preprocess (pps ppx_jane)))
 

--- a/dice.opam
+++ b/dice.opam
@@ -17,6 +17,7 @@ depends: [
   "yojson"
   "ctypes"
   "ctypes-foreign"
+  "bignum"
 ]
 
 pin-depends: [

--- a/lib/Compiler.mli
+++ b/lib/Compiler.mli
@@ -30,7 +30,7 @@ type compiled_program = {
 (** Compile the input program to a [compiled_program] *)
 val compile_program: CoreGrammar.program -> eager_eval:bool -> compiled_program
 
-val get_prob: CoreGrammar.program -> float
+val get_prob: CoreGrammar.program -> Bignum.t
 
 exception Syntax_error of string
 

--- a/lib/CoreGrammar.ml
+++ b/lib/CoreGrammar.ml
@@ -14,7 +14,7 @@ type expr =
   | Ite of expr * expr * expr
   | True
   | False
-  | Flip of float
+  | Flip of Bignum.t
   | Let of String.t * expr * expr
   | FuncCall of String.t * expr List.t
   | Observe of expr
@@ -29,6 +29,7 @@ type typ =
     TBool
   | TTuple of typ * typ
 [@@deriving sexp_of]
+
 
 type arg = String.t * typ
 [@@deriving sexp_of]
@@ -142,7 +143,7 @@ let string_of_prog_unparsed p =
     | Observe(e1) | Fst(e1) | Snd(e1) | Sample(e1) ->
       let s1 = pr_expr e1 in
       Format.dprintf "@[<hov 2>%s@ %t@]" (string_of_op e) s1
-    | Flip(f) -> Format.dprintf "flip %s" (Format.asprintf "%f" f)
+    | Flip(f) -> Format.dprintf "flip %s" (Bignum.to_string_hum f)
     | Ident(s) -> Format.dprintf "%s" s
     | FuncCall(id, args) ->
       let args_s = 

--- a/lib/CoreGrammar.mli
+++ b/lib/CoreGrammar.mli
@@ -1,6 +1,7 @@
 (** Defines the core internal dice grammar *)
 
 
+
 type expr =
   | And of expr * expr
   | Or of expr * expr
@@ -15,7 +16,7 @@ type expr =
   | Ite of expr * expr * expr
   | True
   | False
-  | Flip of float
+  | Flip of Bignum.t
   | Let of String.t * expr * expr
   | FuncCall of String.t * expr List.t
   | Observe of expr

--- a/lib/ExternalGrammar.ml
+++ b/lib/ExternalGrammar.ml
@@ -65,7 +65,7 @@ type eexpr =
   | FuncCall of source * String.t * eexpr List.t
   | Iter of source * String.t * eexpr * int
   | Unif of source * int * int * int 
-  | Binom of source * int * int * float
+  | Binom of source * int * int * Bignum.t
   | True of source
   | False of source
   | ListLit of source * eexpr List.t

--- a/lib/ExternalGrammar.ml
+++ b/lib/ExternalGrammar.ml
@@ -4,6 +4,7 @@
 
 open Core
 open Sexplib.Std
+open Bignum
 
 type typ =
     TBool
@@ -40,11 +41,11 @@ type eexpr =
   | IntConst of source * int
   | Not of source * eexpr
   | Ite of source * eexpr * eexpr * eexpr
-  | Flip of source * float
+  | Flip of source * Bignum.t
   | Let of source * String.t * eexpr * eexpr
   | Observe of source * eexpr
   | Ident of source * String.t
-  | Discrete of source * float List.t
+  | Discrete of source * Bignum.t List.t
   | Int of source * int * int (* value, size *)
   | Eq of source * eexpr * eexpr
   | LeftShift of source * eexpr * int

--- a/lib/Parser.mly
+++ b/lib/Parser.mly
@@ -84,7 +84,7 @@ expr:
     | TAIL expr { Tail({startpos=$startpos; endpos=$endpos}, $2) }
     | LENGTH expr { Length({startpos=$startpos; endpos=$endpos}, $2) }
     | UNIFORM LPAREN sz=INT_LIT COMMA b=INT_LIT COMMA e=INT_LIT RPAREN { Unif ({startpos=$startpos; endpos=$endpos}, sz, b, e)}
-    | BINOMIAL LPAREN sz=INT_LIT COMMA n=INT_LIT COMMA p=FLOAT_LIT RPAREN { Binom({startpos=$startpos; endpos=$endpos}, sz, n, p)}
+    | BINOMIAL LPAREN sz=INT_LIT COMMA n=INT_LIT COMMA p=num RPAREN { Binom({startpos=$startpos; endpos=$endpos}, sz, n, p)}
 
 typ:
     | BOOL { TBool }

--- a/lib/Passes.ml
+++ b/lib/Passes.ml
@@ -245,11 +245,11 @@ type ast =
   | IntConst of source * int
   | Not of source * tast
   | Ite of source * tast * tast * tast
-  | Flip of source * float
+  | Flip of source * Bignum.t
   | Let of source * String.t * tast * tast
   | Observe of source * tast
   | Ident of source * String.t
-  | Discrete of source * float List.t
+  | Discrete of source * Bignum.t List.t
   | Int of source * int * int (* value, size *)
   | Eq of source * tast * tast
   | Plus of source * tast * tast
@@ -267,7 +267,7 @@ type ast =
   | FuncCall of source * String.t * tast List.t
   | Iter of source * String.t * tast * int
   | Unif of source * int * int * int
-  | Binom of source * int * int * float
+  | Binom of source * int * int * Bignum.t
   | True of source
   | False of source
   | ListLit of source * tast List.t
@@ -352,7 +352,7 @@ let rec type_of (cfg: config) (ctx: typ_ctx) (env: EG.tenv) (e: EG.eexpr) : tast
     (TBool, Observe(s, s1))
   | True(s) -> (TBool, True(s))
   | False(s) -> (TBool, False(s))
-  | Flip(s, f) -> (TBool, Flip(s,f))
+  | Flip(s, f) -> (TBool, Flip(s, f))
   | Ident(src, s) ->
     let t = (try Map.Poly.find_exn env s
      with _ -> raise (Type_error (Format.sprintf "Type error at line %d column %d: \
@@ -383,7 +383,7 @@ let rec type_of (cfg: config) (ctx: typ_ctx) (env: EG.tenv) (e: EG.eexpr) : tast
                            src.startpos.pos_lnum (get_col src.startpos)))) else ();
     (TInt(sz), Int(src, sz, v))
   | Discrete(src, l) ->
-    let sum = List.fold l ~init:0.0 ~f:(fun acc i -> acc +. i) in
+    let sum = List.fold (List.map l Bignum.to_float) ~init:0.0 ~f:(fun acc i -> acc +. i) in
     if not (within_epsilon sum 1.0) then
       raise (Type_error (Format.sprintf "Type error at line %d column %d: discrete parameters must sum to 1, got %f"
                            src.startpos.pos_lnum (get_col src.startpos) sum))
@@ -568,9 +568,9 @@ let rec gen_discrete mgr (l: float List.t) =
       (* now build the expression *)
       (match l with
        | [] -> failwith "unreachable"
-       | [(_, param)] -> [cur_name, Flip(param)]
+       | [(_, param)] -> [cur_name, Flip((Bignum.of_float_dyadic param))]
        | (_, param)::xs ->
-         let ifbody = List.fold xs ~init:(Flip(param)) ~f:(fun acc (guard, param) -> Ite(guard, Flip(param), acc)) in
+         let ifbody = List.fold xs ~init:(Flip((Bignum.of_float_dyadic param))) ~f:(fun acc (guard, param) -> Ite(guard, Flip((Bignum.of_float_dyadic param)), acc)) in
          [cur_name, ifbody]
       ) @ acc
     ) in
@@ -778,7 +778,7 @@ let rec from_external_expr_h (ctx: external_ctx) (cfg: config) ((t, e): tast) : 
   | Not(_, e) -> Not(from_external_expr_h ctx cfg e)
   | Flip(_, f) -> Flip(f)
   | Ident(_, s) -> Ident(s)
-  | Discrete(_, l) -> gen_discrete ctx l
+  | Discrete(_, l) -> gen_discrete ctx (List.map l Bignum.to_float)
   | Unif(s, sz, b, e) -> 
 	  assert(b >= 0);
 	  assert(e > b);
@@ -786,7 +786,7 @@ let rec from_external_expr_h (ctx: external_ctx) (cfg: config) ((t, e): tast) : 
 	  let rec make_flip_list bit_count length = 
 		  if length = 0 then []
 		  else if length > bit_count then CG.False :: (make_flip_list bit_count (length-1))
-		  else CG.Flip(0.5) :: (make_flip_list bit_count (length-1)) in
+		  else CG.Flip(Bignum.(1 // 2)) :: (make_flip_list bit_count (length-1)) in
 	  let make_simple_unif bit_count length = 
 		  mk_dfs_tuple (make_flip_list bit_count length) in 
 	  let is_power_of_two num = 
@@ -798,7 +798,7 @@ let rec from_external_expr_h (ctx: external_ctx) (cfg: config) ((t, e): tast) : 
 		  let power_lt_float = 2.0 ** (float_of_int((num_binary_digits e) - 1)) in
 		  let power_lt_int = int_of_float power_lt_float in 
 		  from_external_expr_h ctx cfg 
-			  (TInt(sz), Ite(s, 	(TBool, Flip(s, power_lt_float /. (float_of_int e))), 
+			  (TInt(sz), Ite(s, 	(TBool, Flip(s, Bignum.(power_lt_int // e))), 
 								  (TInt(sz), Unif(s, sz, 0, power_lt_int)), 
 								  (TInt(sz), Unif(s, sz, power_lt_int, e))))
   | Binom(s, sz, n, p) -> 

--- a/lib/Passes.ml
+++ b/lib/Passes.ml
@@ -568,9 +568,9 @@ let rec gen_discrete mgr (l: float List.t) =
       (* now build the expression *)
       (match l with
        | [] -> failwith "unreachable"
-       | [(_, param)] -> [cur_name, Flip((Bignum.of_float_dyadic param))]
+       | [(_, param)] -> [cur_name, Flip((Bignum.of_float_decimal param))]
        | (_, param)::xs ->
-         let ifbody = List.fold xs ~init:(Flip((Bignum.of_float_dyadic param))) ~f:(fun acc (guard, param) -> Ite(guard, Flip((Bignum.of_float_dyadic param)), acc)) in
+         let ifbody = List.fold xs ~init:(Flip((Bignum.of_float_decimal param))) ~f:(fun acc (guard, param) -> Ite(guard, Flip((Bignum.of_float_decimal param)), acc)) in
          [cur_name, ifbody]
       ) @ acc
     ) in

--- a/lib/Wmc.ml
+++ b/lib/Wmc.ml
@@ -2,25 +2,30 @@ open Core
 open Bdd
 
 (** map from variable index to (low weight, high weight) *)
-type weight = (label, (float*float)) Hashtbl.Poly.t
+type weight = (label, (Bignum.t*Bignum.t)) Core.Hashtbl.Poly.t
+
+let hashtable_to_float (low, high) = 
+  (Bignum.to_float low, Bignum.to_float high) 
 
 (** Perform a weighted model count of the BDD `bdd` with weight function `w` *)
-let wmc mgr (bdd : bddptr) (w: weight) =
+let wmc ~float_wmc mgr (bdd : bddptr) (w: weight) =
   (* internal memoized recursive weighted model count *)
-  let rec wmc_rec bdd w cache : float=
-    if bdd_is_true mgr bdd then 1.0
-    else if bdd_is_false mgr bdd then 0.0
+  let rec wmc_rec bdd w cache addop multop one zero =
+    if bdd_is_true mgr bdd then one
+    else if bdd_is_false mgr bdd then zero
     else match Hashtbl.Poly.find cache bdd with
       | Some v -> v
       | _ ->
         (* compute weight of children *)
         let (thn, els) = (bdd_high mgr bdd, bdd_low mgr bdd) in
-        let thnw = wmc_rec thn w cache and
-          elsw = wmc_rec els w cache in
+        let thnw = wmc_rec thn w cache addop multop one zero and
+          elsw = wmc_rec els w cache addop multop one zero in
         (* compute new weight, add to cache *)
         let (loww, highw) = try Hashtbl.Poly.find_exn w (bdd_topvar mgr bdd)
           with _ -> failwith (Format.sprintf "Could not find variable %d" (Bdd.int_of_label (bdd_topvar mgr bdd)))in
-        let new_weight = (highw *. thnw) +. (loww *. elsw) in
+        let new_weight = (addop (multop highw thnw) (multop loww elsw)) in
         Hashtbl.Poly.add_exn cache ~key:bdd ~data:new_weight;
         new_weight in
-  wmc_rec bdd w (Hashtbl.Poly.create ())
+  if float_wmc then Bignum.of_float_decimal
+          (wmc_rec bdd (Hashtbl.Poly.map w hashtable_to_float) (Hashtbl.Poly.create ()) (+.) ( *. ) 1. 0.) 
+    else wmc_rec bdd w (Hashtbl.Poly.create ()) Bignum.(+) Bignum.( * ) Bignum.one Bignum.zero

--- a/lib/Wmc.mli
+++ b/lib/Wmc.mli
@@ -1,5 +1,5 @@
 
-type weight = (Bdd.label, (float*float)) Core.Hashtbl.Poly.t
+type weight = (Bdd.label, (Bignum.t*Bignum.t)) Core.Hashtbl.Poly.t
 
 (** Performs a weighted model count of the BDD with the supplied weight function. *)
-val wmc : Bdd.manager -> Bdd.bddptr -> weight -> float
+val wmc : float_wmc:bool -> Bdd.manager -> Bdd.bddptr -> weight -> Bignum.t

--- a/lib/dune
+++ b/lib/dune
@@ -17,7 +17,7 @@
 
 
 (library
- (libraries core cudd sexplib menhirLib ounit2 ctypes ctypes.foreign)
+ (libraries core cudd sexplib menhirLib ounit2 ctypes ctypes.foreign bignum)
  (foreign_archives rsdd)
  (library_flags (-linkall))
  (name diceLib)

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -81,7 +81,7 @@ rule token =
     | ':'                       { COLON }
     | ','                       { COMMA }
     | int as i                  { INT_LIT(int_of_string i); }
-    | float as num              { FLOAT_LIT(float_of_string num); }
+    | float as num              { FLOAT_LIT(num); }
     | id as ident               { ID(ident); }
     | eof                       { EOF }
 and comment =


### PR DESCRIPTION
Changes
- `flip`. `discrete`, and `binomial` now support integer and rational arguments (where previously floats were required)
- internal representations modified to use arbitrary-precision rationals
- WMC now uses rational operations by default
- `-float-wmc` flag added, setting WMC to use float operations
