### PR TITLE
Added log-floating point based computation

### DIFF
--- a/bin/dice.ml
+++ b/bin/dice.ml
@@ -181,7 +181,7 @@ let command =
      and eager_eval = flag "-eager-eval" no_arg ~doc:" eager let compilation"
      and recursion_limit = flag "-recursion-limit" (optional int) ~doc:" maximum recursion depth"
      and max_list_length = flag "-max-list-length" (optional int) ~doc:" maximum list length"
-     and wmc_type = flag "-wmc-type" (optional_with_default 0 int) ~doc:" choose wmc computation (0: log based, 1: rational based, 2: float based)"
+     and wmc_type = flag "-wmc-type" (optional_with_default 0 int) ~doc:" choose computation type (0: log based [default], 1: rational based, 2: float based)"
      (* and print_marginals = flag "-show-marginals" no_arg ~doc:" print the marginal probabilities of a tuple in depth-first order" *)
      and json = flag "-json" no_arg ~doc:" print output as JSON"
      in fun () ->

--- a/bin/dice.ml
+++ b/bin/dice.ml
@@ -60,7 +60,7 @@ let parse_and_print ~print_parsed ~print_internal ~print_size ~skip_table
     ~inline_functions ~sample_amount ~show_recursive_calls
     ~flip_lifting ~branch_elimination ~determinism ~print_state_bdd
     ~show_function_size ~print_unparsed ~print_function_bdd
-    ~recursion_limit ~max_list_length ~eager_eval ~float_wmc
+    ~recursion_limit ~max_list_length ~eager_eval ~wmc_type
     lexbuf : result List.t = try
   let parsed = Compiler.parse_with_error lexbuf in
   let res = if print_parsed then [StringRes("Parsed program", (ExternalGrammar.string_of_prog parsed))] else [] in
@@ -84,12 +84,13 @@ let parse_and_print ~print_parsed ~print_internal ~print_size ~skip_table
     let compiled = Compiler.compile_program internal ~eager_eval in
     let zbdd = compiled.body.z in
     let res = if skip_table then res else res @
-       (let z = Wmc.wmc ~float_wmc compiled.ctx.man zbdd compiled.ctx.weights in
+       (let z = Wmc.wmc ~wmc_type compiled.ctx.man zbdd compiled.ctx.weights in
        let table = VarState.get_table cfg compiled.ctx.man compiled.body.state t in
        let probs = List.map table ~f:(fun (label, bdd) ->
-           if Bignum.(z = zero) then (label, Bignum.zero) else
-             let prob = Bignum.((Wmc.wmc ~float_wmc compiled.ctx.man (Bdd.bdd_and compiled.ctx.man bdd zbdd) compiled.ctx.weights) / z) in
-             (label, prob)) in
+          if (Bignum.(z = zero) && (wmc_type = 1 || wmc_type = 2)) || Bignum.((den z) = zero) then (label, Bignum.zero) else 
+             let numer = (Wmc.wmc ~wmc_type compiled.ctx.man (Bdd.bdd_and compiled.ctx.man bdd zbdd) compiled.ctx.weights) in
+             let div_res = if wmc_type = 1 || wmc_type = 2 then Bignum.(numer / z) else LogProbability.rat_div_and_conv numer z in 
+             (label, div_res)) in
        let l = [["Value"; "Probability"]] @
          List.map probs ~f:(fun (typ, prob) -> [print_pretty typ; Bignum.to_string_hum prob]) in
        [TableRes("Joint Distribution", l)]
@@ -180,7 +181,7 @@ let command =
      and eager_eval = flag "-eager-eval" no_arg ~doc:" eager let compilation"
      and recursion_limit = flag "-recursion-limit" (optional int) ~doc:" maximum recursion depth"
      and max_list_length = flag "-max-list-length" (optional int) ~doc:" maximum list length"
-     and float_wmc = flag "-float-wmc" no_arg ~doc:" use float-based wmc"
+     and wmc_type = flag "-wmc-type" (optional_with_default 0 int) ~doc:" choose wmc computation (0: log based, 1: rational based, 2: float based)"
      (* and print_marginals = flag "-show-marginals" no_arg ~doc:" print the marginal probabilities of a tuple in depth-first order" *)
      and json = flag "-json" no_arg ~doc:" print output as JSON"
      in fun () ->
@@ -191,7 +192,7 @@ let command =
                   ~print_size ~inline_functions ~skip_table ~flip_lifting
                   ~branch_elimination ~determinism ~show_recursive_calls ~print_state_bdd
                   ~show_function_size ~print_unparsed ~print_function_bdd
-                  ~recursion_limit ~max_list_length ~eager_eval ~float_wmc
+                  ~recursion_limit ~max_list_length ~eager_eval ~wmc_type
                   lexbuf) in
        if json then Format.printf "%s" (Yojson.to_string (`List(List.map r ~f:json_res)))
        else List.iter r ~f:print_res

--- a/lib/Compiler.ml
+++ b/lib/Compiler.ml
@@ -248,10 +248,10 @@ let compile_program (p:program) ~eager_eval : compiled_program =
 
 let get_prob p =
   let c = compile_program ~eager_eval:false p in
-  let z = Wmc.wmc ~float_wmc:false c.ctx.man c.body.z c.ctx.weights in
-  let prob = Wmc.wmc ~float_wmc:false c.ctx.man (Bdd.bdd_and c.ctx.man (extract_leaf c.body.state) c.body.z) c.ctx.weights in
+  let z = Wmc.wmc ~wmc_type:0 c.ctx.man c.body.z c.ctx.weights in
+  let prob = Wmc.wmc ~wmc_type:0 c.ctx.man (Bdd.bdd_and c.ctx.man (extract_leaf c.body.state) c.body.z) c.ctx.weights in
   (* Format.printf "prob: %f, z: %f" prob z; *)
-  Bignum.(prob / z)
+  LogProbability.rat_div_and_conv prob z
 
 
 module I = Parser.MenhirInterpreter

--- a/lib/LogProbability.ml
+++ b/lib/LogProbability.ml
@@ -2,16 +2,20 @@ type t = float
 
 let mult a b = a +. b
 
+let conv a = a
 let to_dec a = exp a
 let div a b = a -. b
 
 let add a b =
+  if (Float.is_infinite a && Float.is_infinite b) then Float.neg_infinity else
   if b < a then
     a +. (log1p (exp (b -. a)))
   else
     b +. (log1p (exp (a -. b)))
 
 let make a = log a
+
+let rat_div_and_conv a b = Bignum.of_float_decimal (exp ((Bignum.to_float a) -. (Bignum.to_float b)))
 
 let to_string base t =
   string_of_float (t /. log base)

--- a/lib/LogProbability.mli
+++ b/lib/LogProbability.mli
@@ -1,10 +1,12 @@
 type t
 
 val mult : t -> t -> t
+val conv: t -> float
 val add : t -> t -> t
 val div : t -> t -> t
 val to_dec : t -> float
 val make : float -> t
+val rat_div_and_conv : Bignum.t -> Bignum.t -> Bignum.t
 
 (** prints the logarithm in the chosen base *)
 val to_string : float -> t -> string

--- a/lib/Wmc.mli
+++ b/lib/Wmc.mli
@@ -2,4 +2,4 @@
 type weight = (Bdd.label, (Bignum.t*Bignum.t)) Core.Hashtbl.Poly.t
 
 (** Performs a weighted model count of the BDD with the supplied weight function. *)
-val wmc : float_wmc:bool -> Bdd.manager -> Bdd.bddptr -> weight -> Bignum.t
+val wmc : wmc_type: int -> Bdd.manager -> Bdd.bddptr -> weight -> Bignum.t


### PR DESCRIPTION
Changes
- Added log based computation in WMC, now used as default rather than rational based computation
- Flag `-float-wmc` changed to `-wmc-type`, accepting `int` arguments `1` (for rational based computation) , `2` (for original float based computation, `0` (default, for log-float based computation) (any other `int` argument will be treated as default)