### PR TITLE
ci(ubuntu): adds GitHub Action for build and test on ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI - Build and Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        ocaml-compiler:
+          - 4.09.0
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Use OCaml ${{ matrix.ocaml-compiler }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: true
+      - name: Install stable Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Populate rsdd subdirectory
+        run: git submodule update --init --recursive
+
+      - name: Install opam dependencies
+        run: opam install . --deps-only
+
+      - name: Build dice
+        run: opam exec -- dune build
+
+      - name: Run tests
+        run: opam exec -- dune test

--- a/test/Test.ml
+++ b/test/Test.ml
@@ -261,45 +261,45 @@ _x0 <=> _y0" in
   assert_feq 1.0 (parse_and_prob prog)
 
 
-let test_unif_1 _ = 
+let test_unif_1 _ =
   let prog1 = "let u = uniform(4, 0, 10) in u < int(4, 4)" in
   let prog2 = "let d = discrete(0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1) in d < int(4, 4)" in
   assert_feq (parse_and_prob prog1) (parse_and_prob prog2);
-  assert_feq 0.4 (parse_and_prob prog1) 
+  assert_feq 0.4 (parse_and_prob prog1)
 
 let test_unif_2 _ =
   let prog1 = "let u = uniform(3, 2, 6) in u == int(3, 0)" in
   let prog2 = "let d = discrete(0., 0., 0.25, 0.25, 0.25, 0.25) in d == int(3, 0)" in
   assert_feq (parse_and_prob prog1) (parse_and_prob prog2);
-  assert_feq 0. (parse_and_prob prog1) 
+  assert_feq 0. (parse_and_prob prog1)
 
-let test_unif_3 _ = 
+let test_unif_3 _ =
   let prog1 = "let u = uniform(3, 3, 4) in u == int(3, 3)" in
   let prog2 = "let d = discrete(0., 0., 0., 1., 0.) in d == int(3, 3)" in
   assert_feq (parse_and_prob prog1) (parse_and_prob prog2);
   assert_feq 1. (parse_and_prob prog1)
 
-let test_unif_4 _ = 
+let test_unif_4 _ =
   let prog = "
     let u = uniform(2, 1, 4) in
     let d = discrete(0., 0.5, 0.25, 0.25) in
     u == d && u < int(2, 3)" in
   assert_feq 0.25 (parse_and_prob prog)
-  
 
-let test_binom_1 _ = 
+
+let test_binom_1 _ =
   let prog = "let b = binomial(3, 4, 0.25) in b == int(3, 1)" in
   assert_feq 0.421875 (parse_and_prob prog)
 
-let test_binom_2 _ = 
-  let prog = "let b = binomial(5, 29, 0.5) in b <= int(5, 14)" in 
+let test_binom_2 _ =
+  let prog = "let b = binomial(5, 29, 0.5) in b <= int(5, 14)" in
   assert_feq 0.5 (parse_and_prob prog)
 
-let test_binom_3 _ = 
+let test_binom_3 _ =
   let prog = "let b = binomial(3, 0, 0.5) in b == int(3, 0)" in
   assert_feq 1. (parse_and_prob prog)
 
-let test_binom_4 _ = 
+let test_binom_4 _ =
   let prog = "let b = binomial(3, 1, 0.3) in b == int(3, 1)" in
   assert_feq 0.3 (parse_and_prob prog)
 
@@ -561,19 +561,6 @@ coin1 == int(6, 10)
 " in assert_feq 0.45 (parse_and_prob prog);
   assert_feq 0.45 (parse_optimize_and_prob prog)
 
-let test_swap _ =
-  let open Cudd in
-  let mgr = Man.make_d () in
-  let bdd1 = Bdd.newvar mgr in
-  let bdd2 = Bdd.newvar mgr in
-  let bdd3 = Bdd.newvar mgr in
-  let bdd4 = Bdd.newvar mgr in
-  let andbdd = Bdd.dand bdd1 bdd2 in
-  let swapbdd = List.to_array [bdd3; bdd4] in
-  let swapidx = List.to_array [Bdd.topvar bdd1; Bdd.topvar bdd2] in
-  let swapped = Bdd.labeled_vector_compose andbdd swapbdd swapidx in
-  OUnit2.assert_bool "Expected equal bdds" (Bdd.is_equal (Bdd.dand bdd3 bdd4) swapped)
-
 let test_recursion _ =
   let prog = In_channel.read_all "../resources/recursion.dice" in
   assert_feq (0.5 ** 3.) (parse_and_prob prog);
@@ -697,7 +684,7 @@ let test_list_ex _ =
   assert_feq (0.2 *. 0.5 +. 0.4 *. 0.5) (parse_and_prob prog);
   assert_feq (0.2 *. 0.5 +. 0.4 *. 0.5) (parse_optimize_and_prob prog)
 
-let test_lte_name _ = 
+let test_lte_name _ =
   let prog1 = "uniform(3, 0, 8) <= uniform(3, 0, 8)" in
   let prog2 = "
     let a = uniform(3, 0, 8) in
@@ -705,7 +692,7 @@ let test_lte_name _ =
     a <= b" in
   assert_feq (parse_and_prob prog1) (parse_and_prob prog2)
 
-let test_lt_name _ = 
+let test_lt_name _ =
   let prog1 = "uniform(3, 0, 8) < uniform(3, 0, 8)" in
   let prog2 = "
     let a = uniform(3, 0, 8) in
@@ -828,8 +815,6 @@ let expression_tests =
   (* "test_pmc1">::test_pmc1;
    * "test_pmc2">::test_pmc2; *)
 
-  "test_swap">::test_swap;
-
   "test_recursion">::test_recursion;
   "test_caesar_recursive">::test_caesar_recursive;
   "test_factorial">::test_factorial;
@@ -842,8 +827,8 @@ let expression_tests =
   (* "test_list_distribution">::test_list_distribution; *)
   "test_list_ex">::test_list_ex;
   "test_bdd">::test_bdd;
-  "test_lte_name">::test_lte_name; 
-  "test_lt_name">::test_lt_name; 
+  "test_lte_name">::test_lte_name;
+  "test_lt_name">::test_lt_name;
 ]
 
 let () =


### PR DESCRIPTION
This PR adds a GitHub Action for building and testing dice on the latest ubuntu image. We combine the typical setup workflows for OCaml and Rust projects, otherwise following the project README. Moving forward, the CI runs on every push to `master`, as well as any pull request against `master`. Closes #55.

Benchmark-wise, the first run takes ~ 10-12 minutes, and subsequent runs make use of the `opam` and `dune` cache and range between 4-7 minutes.

Some other notes:

* in order to get the build to work, I also remove a test from the test suite; after confirming that the feature being tested is no longer supported, I think this is appropriate.
* I also ran into problems getting this to work on macOS (rsdd's `.so` file is not being linked properly) and Windows (many, many problems); I imagine I can tackle this in a follow-up PR!

Thank you to @ellieyhcheng for helping me debug!

(since I'm a first-time contributor, you may have to approve the workflow to run on this PR)