### PR TITLE
build/ci(macos): fixes macOS build failure, adds macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macos-latest
         ocaml-compiler:
           - 4.09.0
 

--- a/lib/dune
+++ b/lib/dune
@@ -11,6 +11,7 @@
   (no-infer
     (progn
       (chdir ../rsdd (run cargo build --release))
+      (copy ../rsdd/target/release/librsdd.dylib ../rsdd/target/release/librsdd.so)
       (copy ../rsdd/target/release/librsdd.so dllrsdd.so)
       (copy ../rsdd/target/release/librsdd.a librsdd.a)
       ))))
@@ -22,4 +23,3 @@
  (library_flags (-linkall))
  (name diceLib)
  (preprocess (pps ppx_jane)))
-

--- a/lib/dune
+++ b/lib/dune
@@ -5,13 +5,26 @@
 (ocamllex lexer)
 
 (rule
+ (enabled_if (= %{system} macosx))
  (deps (source_tree ../rsdd))
  (targets librsdd.a dllrsdd.so)
  (action
   (no-infer
     (progn
       (chdir ../rsdd (run cargo build --release))
-      (copy ../rsdd/target/release/librsdd.dylib ../rsdd/target/release/librsdd.so)
+      (copy ../rsdd/target/release/librsdd.dylib dllrsdd.so
+      )
+      (copy ../rsdd/target/release/librsdd.a librsdd.a)
+      ))))
+
+(rule
+ (enabled_if (<> %{system} macosx))
+ (deps (source_tree ../rsdd))
+ (targets librsdd.a dllrsdd.so)
+ (action
+  (no-infer
+    (progn
+      (chdir ../rsdd (run cargo build --release))
       (copy ../rsdd/target/release/librsdd.so dllrsdd.so)
       (copy ../rsdd/target/release/librsdd.a librsdd.a)
       ))))


### PR DESCRIPTION
This PR fixes dice not being built from source properly on macOS. To quickly explain the problem:

* in https://github.com/SHoltzen/dice/commit/95a64ddd2fd15e782c6c3797fe625f527122257e, the `dllrsdd.so` target is added, which requires a file at `../rsdd/target/release/librsdd.so`
* `cargo build --release` uses the [`crate-type`](https://doc.rust-lang.org/cargo/reference/cargo-targets.html#the-crate-type-field) field
* `crate-type` conditionally generates `.dylib` files on macOS and `.so` files on linux
  * on macOS, it will build `../rsdd/target/release/librsdd.dylib`
* so, the new `dllrsdd.so` target will fail on macOS, since the required file doesn't exist

To address this problem, this PR splits the existing rule into two versions using the approach described in https://github.com/ocaml/dune/issues/2310, using the [`enabled_if` optional field](https://dune.readthedocs.io/en/stable/dune-files.html#rule). The two versions of the rule are:

1. For macOS, `dllrsdd.so` depends on `../rsdd/target/release/librsdd.dylib`
2. For "not macOS" (i.e., linux), `dllrsdd.so` depends on `../rsdd/target/release/librsdd.so`

This does require a bit of code duplication, but I wasn't able to find an easier way to do this (for example, by using the `select` form or the configurator).

Then, since the macOS build now works, I add a macOS build to the CI matrix.

Let me know what you think!